### PR TITLE
Update provider to support more Linux images

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ This will create a new Windows runner pool for the repo with ID `26ae13a1-13e9-4
 
 Here is an example for a Linux pool that uses the image specified by its image name:
 
-**NOTE**: The provider supports only **UBUNTU** and **DEBIAN** images for Linux pools at the moment.
-
 ```bash
 garm-cli pool create \
     --os-type linux \

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.3
 require (
 	cloud.google.com/go/compute v1.23.3
 	github.com/BurntSushi/toml v1.3.2
-	github.com/cloudbase/garm-provider-common v0.1.2-0.20240111235646-a9efac12b060
+	github.com/cloudbase/garm-provider-common v0.1.2-0.20240216125425-bbe4930a1ebf
 	golang.org/x/oauth2 v0.16.0
 	google.golang.org/api v0.156.0
 	google.golang.org/protobuf v1.32.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudbase/garm-provider-common v0.1.2-0.20240111235646-a9efac12b060 h1:R1x91MisDJq61uioMULPycnQo6P4HWFyR3Pa9ePz8c4=
-github.com/cloudbase/garm-provider-common v0.1.2-0.20240111235646-a9efac12b060/go.mod h1:igxJRT3OlykERYc6ssdRQXcb+BCaeSfnucg6I0OSoDc=
+github.com/cloudbase/garm-provider-common v0.1.2-0.20240216125425-bbe4930a1ebf h1:E5TVBkaxlX6hoBo5RVEWumjkjT9QM7Y421gGUVJg7so=
+github.com/cloudbase/garm-provider-common v0.1.2-0.20240216125425-bbe4930a1ebf/go.mod h1:igxJRT3OlykERYc6ssdRQXcb+BCaeSfnucg6I0OSoDc=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/vendor/github.com/cloudbase/garm-provider-common/cloudconfig/cloudconfig.go
+++ b/vendor/github.com/cloudbase/garm-provider-common/cloudconfig/cloudconfig.go
@@ -34,6 +34,7 @@ func NewDefaultCloudInitConfig() *CloudInit {
 			"curl",
 			"tar",
 		},
+		Users: []string{"default"},
 		SystemInfo: &SystemInfo{
 			DefaultUser: DefaultUser{
 				Name:   defaults.DefaultUser,
@@ -69,6 +70,7 @@ type File struct {
 type CloudInit struct {
 	mux sync.Mutex
 
+	Users             []string    `yaml:"users"`
 	PackageUpgrade    bool        `yaml:"package_upgrade"`
 	Packages          []string    `yaml:"packages,omitempty"`
 	SSHAuthorizedKeys []string    `yaml:"ssh_authorized_keys,omitempty"`

--- a/vendor/github.com/cloudbase/garm-provider-common/cloudconfig/templates.go
+++ b/vendor/github.com/cloudbase/garm-provider-common/cloudconfig/templates.go
@@ -154,6 +154,10 @@ SVC_NAME=$(cat /home/{{ .RunnerUsername }}/actions-runner/.service)
 sendStatus "generating systemd unit file"
 getRunnerFile "systemd/unit-file?runAsUser={{ .RunnerUsername }}" "$SVC_NAME" || fail "failed to get service file"
 sudo mv $SVC_NAME /etc/systemd/system/ || fail "failed to move service file"
+sudo chown root:root /etc/systemd/system/$SVC_NAME || fail "failed to change owner"
+if [ -e "/sys/fs/selinux" ];then
+	sudo chcon -h system_u:object_r:systemd_unit_file_t:s0 /etc/systemd/system/$SVC_NAME || fail "failed to change selinux context"
+fi
 
 sendStatus "enabling runner service"
 cp /home/{{ .RunnerUsername }}/actions-runner/bin/runsvc.sh /home/{{ .RunnerUsername }}/actions-runner/ || fail "failed to copy runsvc.sh"
@@ -202,8 +206,7 @@ sudo ./svc.sh install {{ .RunnerUsername }} || fail "failed to install service"
 {{- end}}
 
 if [ -e "/sys/fs/selinux" ];then
-	sudo chcon -h user_u:object_r:bin_t /home/runner/ || fail "failed to change selinux context"
-	sudo chcon -R -h {{ .RunnerUsername }}:object_r:bin_t /home/runner/* || fail "failed to change selinux context"
+	sudo chcon -R -h user_u:object_r:bin_t:s0 /home/runner/ || fail "failed to change selinux context"
 fi
 
 AGENT_ID=""

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ cloud.google.com/go/compute/metadata
 ## explicit; go 1.16
 github.com/BurntSushi/toml
 github.com/BurntSushi/toml/internal
-# github.com/cloudbase/garm-provider-common v0.1.2-0.20240111235646-a9efac12b060
+# github.com/cloudbase/garm-provider-common v0.1.2-0.20240216125425-bbe4930a1ebf
 ## explicit; go 1.20
 github.com/cloudbase/garm-provider-common/cloudconfig
 github.com/cloudbase/garm-provider-common/defaults


### PR DESCRIPTION
Due to [Fix SELinux security context on unit file](https://github.com/cloudbase/garm-provider-common/pull/23), the GARM provider supports more Linux images (CentOS, RHEL).