### PR TITLE
Add support for source_snapshot, network_tags, custom_labels extra-specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ To this end, this provider supports the following extra specs schema:
             "items": {
                 "type": "string"
             }
+        },
+        "source_snapshot": {
+            "type": "string",
+            "description": "The source snapshot to create this disk."
         }
     }
 }
@@ -124,7 +128,8 @@ An example of extra specs json would look like this:
     "subnet_id": "projects/garm-testing/regions/europe-west1/subnetworks/garm",
     "nic_type": "VIRTIO_NET",
     "custom_labels": {"environment":"production","project":"myproject"},
-    "network_tags": ["web-server", "production"]
+    "network_tags": ["web-server", "production"],
+    "source_snapshot": "projects/garm-testing/global/snapshots/garm-snapshot"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ To this end, this provider supports the following extra specs schema:
         "nic_type": {
             "type": "string",
             "description": "The type of NIC attached to the instance. Default is VIRTIO_NET."
+        },
+        "custom_labels":{
+            "type": "object",
+            "description": "Custom labels to be attached to the instance. Each label is a key-value pair where both key and value are strings.",
+            "additionalProprieties": {
+                "type": "string"
+            }
         }
     }
 }
@@ -108,9 +115,12 @@ An example of extra specs json would look like this:
     "disksize": 255,
     "network_id": "projects/garm-testing/global/networks/garm-2",
     "subnet_id": "projects/garm-testing/regions/europe-west1/subnetworks/garm",
-    "nic_type": "VIRTIO_NET"
+    "nic_type": "VIRTIO_NET",
+    "custom_labels": {"environment":"production","project":"myproject"}
 }
 ```
+
+**NOTE**: The `custom_labels` must meet the [GCP requirements for labels](https://cloud.google.com/compute/docs/labeling-resources#requirements)!
 
 To set it on an existing pool, simply run:
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,14 @@ To this end, this provider supports the following extra specs schema:
         "custom_labels":{
             "type": "object",
             "description": "Custom labels to be attached to the instance. Each label is a key-value pair where both key and value are strings.",
-            "additionalProprieties": {
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "network_tags": {
+            "type": "array",
+            "description": "A list of network tags to be attached to the instance.",
+            "items": {
                 "type": "string"
             }
         }
@@ -116,11 +123,12 @@ An example of extra specs json would look like this:
     "network_id": "projects/garm-testing/global/networks/garm-2",
     "subnet_id": "projects/garm-testing/regions/europe-west1/subnetworks/garm",
     "nic_type": "VIRTIO_NET",
-    "custom_labels": {"environment":"production","project":"myproject"}
+    "custom_labels": {"environment":"production","project":"myproject"},
+    "network_tags": ["web-server", "production"]
 }
 ```
 
-**NOTE**: The `custom_labels` must meet the [GCP requirements for labels](https://cloud.google.com/compute/docs/labeling-resources#requirements)!
+**NOTE**: The `custom_labels` and `network_tags` must meet the [GCP requirements for labels](https://cloud.google.com/compute/docs/labeling-resources#requirements) and the [GCP requirements for network tags](https://cloud.google.com/vpc/docs/add-remove-network-tags#restrictions)!
 
 To set it on an existing pool, simply run:
 

--- a/internal/client/gcp.go
+++ b/internal/client/gcp.go
@@ -84,16 +84,7 @@ func (g *GcpCli) CreateInstance(ctx context.Context, spec *spec.RunnerSpec) (*co
 	inst := &computepb.Instance{
 		Name:        proto.String(name),
 		MachineType: proto.String(util.GetMachineType(g.cfg.Zone, spec.BootstrapParams.Flavor)),
-		Disks: []*computepb.AttachedDisk{
-			{
-				Boot: proto.Bool(true),
-				InitializeParams: &computepb.AttachedDiskInitializeParams{
-					DiskSizeGb:  proto.Int64(spec.DiskSize),
-					SourceImage: proto.String(spec.BootstrapParams.Image),
-				},
-				AutoDelete: proto.Bool(true),
-			},
-		},
+		Disks:       generateBootDisk(spec.DiskSize, spec.BootstrapParams.Image, spec.SourceSnapshot),
 		NetworkInterfaces: []*computepb.NetworkInterface{
 			{
 				Network: proto.String(g.cfg.NetworkID),
@@ -241,4 +232,24 @@ func selectStartupScript(osType params.OSType) string {
 	default:
 		return ""
 	}
+}
+
+func generateBootDisk(diskSize int64, image, snapshot string) []*computepb.AttachedDisk {
+	disk := []*computepb.AttachedDisk{
+		{
+			Boot: proto.Bool(true),
+			InitializeParams: &computepb.AttachedDiskInitializeParams{
+				DiskSizeGb:     proto.Int64(diskSize),
+				SourceImage:    proto.String(image),
+				SourceSnapshot: proto.String(snapshot),
+			},
+			AutoDelete: proto.Bool(true),
+		},
+	}
+
+	if snapshot != "" {
+		disk[0].InitializeParams.SourceImage = nil
+	}
+
+	return disk
 }

--- a/internal/client/gcp.go
+++ b/internal/client/gcp.go
@@ -116,6 +116,9 @@ func (g *GcpCli) CreateInstance(ctx context.Context, spec *spec.RunnerSpec) (*co
 			},
 		},
 		Labels: spec.CustomLabels,
+		Tags: &computepb.Tags{
+			Items: spec.NetworkTags,
+		},
 	}
 
 	insertReq := &computepb.InsertInstanceRequest{

--- a/internal/client/gcp.go
+++ b/internal/client/gcp.go
@@ -36,9 +36,6 @@ const (
 	linuxStartupScript   string = "startup-script"
 	windowsStartupScript string = "sysprep-specialize-script-ps1"
 	accessConfigType     string = "ONE_TO_ONE_NAT"
-	garmPoolID           string = "garmpoolid"
-	garmControllerID     string = "garmcontrollerid"
-	osType               string = "ostype"
 )
 
 func NewGcpCli(ctx context.Context, cfg *config.Config) (*GcpCli, error) {
@@ -118,11 +115,7 @@ func (g *GcpCli) CreateInstance(ctx context.Context, spec *spec.RunnerSpec) (*co
 				},
 			},
 		},
-		Labels: map[string]string{
-			garmPoolID:       spec.BootstrapParams.PoolID,
-			garmControllerID: spec.ControllerID,
-			osType:           string(spec.BootstrapParams.OSType),
-		},
+		Labels: spec.CustomLabels,
 	}
 
 	insertReq := &computepb.InsertInstanceRequest{

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -68,6 +68,17 @@ func (e *extraSpecs) Validate() error {
 			return fmt.Errorf("custom label key '%s' and value '%s' must be lowercase", k, v)
 		}
 	}
+	if len(e.NetworkTags) > 64 {
+		return fmt.Errorf("network tags cannot exceed 64 items")
+	}
+	for _, tag := range e.NetworkTags {
+		if len(tag) > 63 {
+			return fmt.Errorf("network tag '%s' exceeds 63 characters", tag)
+		}
+		if !utils.IsLower(tag) {
+			return fmt.Errorf("network tag '%s' must be lowercase", tag)
+		}
+	}
 	return nil
 }
 
@@ -77,6 +88,7 @@ type extraSpecs struct {
 	SubnetworkID string            `json:"subnetwork_id,omitempty"`
 	NicType      string            `json:"nic_type,omitempty"`
 	CustomLabels map[string]string `json:"custom_labels,omitempty"`
+	NetworkTags  []string          `json:"network_tags,omitempty"`
 }
 
 func GetRunnerSpecFromBootstrapParams(cfg *config.Config, data params.BootstrapInstance, controllerID string) (*RunnerSpec, error) {
@@ -123,6 +135,7 @@ type RunnerSpec struct {
 	NicType         string
 	DiskSize        int64
 	CustomLabels    map[string]string
+	NetworkTags     []string
 }
 
 func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
@@ -140,6 +153,9 @@ func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
 	}
 	if len(extraSpecs.CustomLabels) > 0 {
 		maps.Copy(r.CustomLabels, extraSpecs.CustomLabels)
+	}
+	if len(extraSpecs.NetworkTags) > 0 {
+		r.NetworkTags = extraSpecs.NetworkTags
 	}
 }
 

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -83,12 +83,13 @@ func (e *extraSpecs) Validate() error {
 }
 
 type extraSpecs struct {
-	DiskSize     int64             `json:"disksize,omitempty"`
-	NetworkID    string            `json:"network_id,omitempty"`
-	SubnetworkID string            `json:"subnetwork_id,omitempty"`
-	NicType      string            `json:"nic_type,omitempty"`
-	CustomLabels map[string]string `json:"custom_labels,omitempty"`
-	NetworkTags  []string          `json:"network_tags,omitempty"`
+	DiskSize       int64             `json:"disksize,omitempty"`
+	NetworkID      string            `json:"network_id,omitempty"`
+	SubnetworkID   string            `json:"subnetwork_id,omitempty"`
+	NicType        string            `json:"nic_type,omitempty"`
+	CustomLabels   map[string]string `json:"custom_labels,omitempty"`
+	NetworkTags    []string          `json:"network_tags,omitempty"`
+	SourceSnapshot string            `json:"source_snapshot,omitempty"`
 }
 
 func GetRunnerSpecFromBootstrapParams(cfg *config.Config, data params.BootstrapInstance, controllerID string) (*RunnerSpec, error) {
@@ -136,6 +137,7 @@ type RunnerSpec struct {
 	DiskSize        int64
 	CustomLabels    map[string]string
 	NetworkTags     []string
+	SourceSnapshot  string
 }
 
 func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
@@ -156,6 +158,9 @@ func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
 	}
 	if len(extraSpecs.NetworkTags) > 0 {
 		r.NetworkTags = extraSpecs.NetworkTags
+	}
+	if extraSpecs.SourceSnapshot != "" {
+		r.SourceSnapshot = extraSpecs.SourceSnapshot
 	}
 }
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -18,6 +18,7 @@ package util
 import (
 	"fmt"
 	"strings"
+	"unicode"
 
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/cloudbase/garm-provider-common/params"
@@ -54,4 +55,13 @@ func GcpInstanceToParamsInstance(gcpInstance *computepb.Instance) (params.Provid
 	}
 
 	return details, nil
+}
+
+func IsLower(s string) bool {
+	for _, r := range s {
+		if !unicode.IsLower(r) && unicode.IsLetter(r) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -18,7 +18,6 @@ package util
 import (
 	"fmt"
 	"strings"
-	"unicode"
 
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/cloudbase/garm-provider-common/params"
@@ -55,13 +54,4 @@ func GcpInstanceToParamsInstance(gcpInstance *computepb.Instance) (params.Provid
 	}
 
 	return details, nil
-}
-
-func IsLower(s string) bool {
-	for _, r := range s {
-		if !unicode.IsLower(r) && unicode.IsLetter(r) {
-			return false
-		}
-	}
-	return true
 }


### PR DESCRIPTION
Solves the following issues:

- #3
- #4
-  #5

This PR adds the following extra-specs to garm-provider-gcp:
- `custom_labels`
- `network_tags`
- `source_snapshot`

Fixes: #3
Fixes: #4
Fixes: #5