### PR TITLE
Add common extra specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,21 @@ To this end, this provider supports the following extra specs schema:
         "source_snapshot": {
             "type": "string",
             "description": "The source snapshot to create this disk."
+        },
+        "enable_boot_debug": {
+            "type": "boolean",
+            "description": "Enable boot debug on the VM."
+        },
+        "runner_install_template": {
+            "type": "string",
+            "description": "This option can be used to override the default runner install template. If used, the caller is responsible for the correctness of the template as well as the suitability of the template for the target OS. Use the extra_context extra spec if your template has variables in it that need to be expanded."
+        },
+        "extra_context": {
+            "type": "object",
+            "description": "Extra context that will be passed to the runner_install_template.",
+            "additionalProperties": {
+                "type": "string"
+            }
         }
     },
 	"additionalProperties": false


### PR DESCRIPTION
The garm-provider-common package gives us a few extra specs we can tweak. Some of those extra specs are useful for systems that use cloud-init to initialize.

Some are useful even without cloud init. The following extra specs are added to the GCP provider:

* enable_boot_debug - sets the -x option
* runner_install_template - allows us to overwrite the default runner install template.
* extra_context - the runner_install_template can be a golang template which can define some variables that can be expanded from a hashtable of string key/value pairs.