### PR TITLE
Allow default credentials source

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,25 @@ project_id = "garm-testing"
 zone = "europe-west1-d"
 network_id = "projects/garm-testing/global/networks/garm"
 subnetwork_id = "projects/garm-testing/regions/europe-west1/subnetworks/garm"
+# The credentials file is optional.
+# Leave this empty if you want to use the default credentials.
 credentials_file = "/home/ubuntu/service-account-key.json"
 external_ip_access = true
+```
+
+NOTE: If you want to pass in credentials by using the `GOOGLE_APPLICATION_CREDENTIALS` environment variable, you can leave the `credentials_file` field empty, but you must pass in the variable to GARM, then in the GARM config file, you must specify that the `GOOGLE_APPLICATION_CREDENTIALS` is safe to pass to the provider by setting the `environment_variables` field to `["GOOGLE_APPLICATION_CREDENTIALS"]`:
+
+```toml
+[[provider]]
+  name = "gcp"
+  provider_type = "external"
+  description = "gcp provider"
+  # This is needed if you want GARM to pass this along to the provider.
+  environment_variables = ["GOOGLE_APPLICATION_CREDENTIALS"]
+  [provider.external]
+    provider_executable = "/opt/garm/providers.d/garm-provider-gcp"
+    config_file = "/etc/garm/garm-provider-gcp.toml"
+
 ```
 
 ## Creating a pool

--- a/config/config.go
+++ b/config/config.go
@@ -55,9 +55,5 @@ func (c *Config) Validate() error {
 	if c.SubnetworkID == "" {
 		return fmt.Errorf("missing subnetwork_id")
 	}
-	if c.CredentialsFile == "" {
-		return fmt.Errorf("missing credentials_file")
-	}
-
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -84,17 +84,6 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			errString: fmt.Errorf("missing subnetwork_id"),
 		},
-		{
-			name: "MissingCredentialsFile",
-			config: &Config{
-				Zone:             "europe-west1-d",
-				ProjectId:        "my-project",
-				NetworkID:        "my-network",
-				SubnetworkID:     "my-subnetwork",
-				ExternalIPAccess: true,
-			},
-			errString: fmt.Errorf("missing credentials_file"),
-		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This change calls FindDefaultCredentials() to create GCP creds. This will allow the provider to use any creds it finds on the system based on the standard places creds are usually stored.

Fixes: #16 