### PR TITLE
Unmask CreateInstance error

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -58,7 +58,7 @@ func (g *GcpProvider) CreateInstance(ctx context.Context, bootstrapParams params
 	}
 	inst, err := g.gcpCli.CreateInstance(ctx, spec)
 	if err != nil {
-		return g.GetInstance(ctx, bootstrapParams.Name)
+		return params.ProviderInstance{}, fmt.Errorf("error creating instance: %w", err)
 	}
 	instance := params.ProviderInstance{
 		ProviderID: *inst.Name,


### PR DESCRIPTION
The error from CreateInstance was being masked by a call to GetInstance.