### PR TITLE
Properly save runner name in GCP metadata

### DIFF
--- a/internal/client/gcp.go
+++ b/internal/client/gcp.go
@@ -155,6 +155,10 @@ func (g *GcpCli) CreateInstance(ctx context.Context, spec *spec.RunnerSpec) (*co
 					Key:   proto.String(selectStartupScript(spec.BootstrapParams.OSType)),
 					Value: proto.String(udata),
 				},
+				{
+					Key:   proto.String("runner_name"),
+					Value: proto.String(spec.BootstrapParams.Name),
+				},
 			},
 		},
 		Labels: spec.CustomLabels,


### PR DESCRIPTION
GARM expects providers to return the runner name and the provider ID of the runner once it's done creating the instance. The GCP provider was mutating the name and converting it to lowercase.

In GCP, the instance name is the ID of the VM and GCP has the requirement that only lowercase letters can be used for instance names.

In GARM, the runner name is the ID, and GARM uses both lower and upper case letters for the name.

The GCP provider was mutating the name and converting it to lowercase. When GARM listed all runners from the provider and cross checked the name to be the same, the check was failing due to the fact that GARM is case sensitive and expected the name to be identical.

This change saves the original name in the metadata of the VM. Labels seem to have the same requirements as the instance name for both keys and values.