### PR TITLE
Adding extra-spec SSH Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,13 @@ To this end, this provider supports the following extra specs schema:
             "type": "string",
             "description": "The source snapshot to create this disk."
         },
+        "ssh_keys": {
+            "type": "array",
+            "description": "A list of SSH keys to be added to the instance. The format is USERNAME:SSH_KEY",
+            "items": {
+                "type": "string"
+            }
+        },
         "enable_boot_debug": {
             "type": "boolean",
             "description": "Enable boot debug on the VM."
@@ -155,7 +162,7 @@ To this end, this provider supports the following extra specs schema:
             }
         }
     },
-	"additionalProperties": false
+    "additionalProperties": false
 }
 ```
 
@@ -169,11 +176,14 @@ An example of extra specs json would look like this:
     "nic_type": "VIRTIO_NET",
     "custom_labels": {"environment":"production","project":"myproject"},
     "network_tags": ["web-server", "production"],
-    "source_snapshot": "projects/garm-testing/global/snapshots/garm-snapshot"
+    "source_snapshot": "projects/garm-testing/global/snapshots/garm-snapshot",
+    "ssh_keys": ["username1:ssh_key1", "username2:ssh_key2"]
 }
 ```
 
 **NOTE**: The `custom_labels` and `network_tags` must meet the [GCP requirements for labels](https://cloud.google.com/compute/docs/labeling-resources#requirements) and the [GCP requirements for network tags](https://cloud.google.com/vpc/docs/add-remove-network-tags#restrictions)!
+
+**NOTE**: The `ssh_keys` add the option to [connect to an instance via SSH](https://cloud.google.com/compute/docs/instances/ssh) (either Linux or Windows). After you added the key as `username:ssh_public_key`, you can use the `private_key` to connect to the Linux/Windows instance via `ssh -i private_rsa username@instance_ip`. For **Windows** instances, the provider installs on the instance `google-compute-engine-ssh` and `enables ssh` if a `ssh_key` is added to extra-specs.
 
 To set it on an existing pool, simply run:
 

--- a/internal/client/gcp_test.go
+++ b/internal/client/gcp_test.go
@@ -147,6 +147,7 @@ func TestCreateInstanceWindows(t *testing.T) {
 		CustomLabels:   map[string]string{"key1": "value1"},
 		NetworkTags:    []string{"tag1", "tag2"},
 		SourceSnapshot: "projects/garm-testing/global/snapshots/garm-snapshot",
+		SSHKeys:        "MockSSHKey",
 		BootstrapParams: params.BootstrapInstance{
 			Name:   "garm-instance",
 			Flavor: "n1-standard-1",
@@ -167,6 +168,14 @@ func TestCreateInstanceWindows(t *testing.T) {
 				{
 					Key:   proto.String(windowsStartupScript),
 					Value: proto.String("MockUserData"),
+				},
+				{
+					Key:   proto.String("ssh-keys"),
+					Value: proto.String("MockSSHKey"),
+				},
+				{
+					Key:   proto.String("enable-windows-ssh"),
+					Value: proto.String("TRUE"),
 				},
 			},
 		},

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -77,6 +77,13 @@ const (
 					"type": "string",
 					"description": "The source snapshot to create this disk."
 				},
+				"ssh_keys": {
+					"type": "array",
+					"description": "A list of SSH keys to be added to the instance.",
+					"items": {
+						"type": "string"
+					}
+				},
 				"enable_boot_debug": {
 					"type": "boolean",
 					"description": "Enable boot debug on the VM."
@@ -181,6 +188,7 @@ type extraSpecs struct {
 	CustomLabels    map[string]string `json:"custom_labels,omitempty"`
 	NetworkTags     []string          `json:"network_tags,omitempty"`
 	SourceSnapshot  string            `json:"source_snapshot,omitempty"`
+	SSHKeys         []string          `json:"ssh_keys,omitempty"`
 	EnableBootDebug *bool             `json:"enable_boot_debug"`
 }
 
@@ -230,6 +238,7 @@ type RunnerSpec struct {
 	CustomLabels    map[string]string
 	NetworkTags     []string
 	SourceSnapshot  string
+	SSHKeys         string
 	EnableBootDebug bool
 }
 
@@ -254,6 +263,11 @@ func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
 	}
 	if extraSpecs.SourceSnapshot != "" {
 		r.SourceSnapshot = extraSpecs.SourceSnapshot
+	}
+	if len(extraSpecs.SSHKeys) > 0 {
+		for key := range extraSpecs.SSHKeys {
+			r.SSHKeys = r.SSHKeys + "\n" + extraSpecs.SSHKeys[key]
+		}
 	}
 	if extraSpecs.EnableBootDebug != nil {
 		r.EnableBootDebug = *extraSpecs.EnableBootDebug

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -42,6 +42,7 @@ func TestJsonSchemaValidation(t *testing.T) {
 				},
 				"network_tags": ["example_tag"],
 				"source_snapshot": "snapshot-id",
+				"ssh_keys": ["ssh-key", "ssh-key2"],
 				"enable_boot_debug": true,
 				"runner_install_template": "install-template",
 				"extra_context": {
@@ -99,6 +100,7 @@ func TestMergeExtraSpecs(t *testing.T) {
 				CustomLabels:    map[string]string{"key1": "value1"},
 				NetworkTags:     []string{"tag1", "tag2"},
 				SourceSnapshot:  "projects/garm-testing/global/snapshots/garm-snapshot",
+				SSHKeys:         []string{"ssh-key1", "ssh-key2"},
 				EnableBootDebug: &enable_boot_debug,
 			},
 		},


### PR DESCRIPTION
Adding the extra-spec option for SSH Keys to allow users to add their own ssh-keys to the Garm instances