### PR TITLE
Add DiskType, DisplayDevice, ServiceAccounts extra-specs options

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ To this end, this provider supports the following extra specs schema:
                 "type": "string"
             }
         },
+        "service_accounts": {
+            "type": "array",
+            "description": "A list of service accounts to be attached to the instance",
+            "items": {
+                "$ref": "#/$defs/ServiceAccount"
+            }
+        },
         "source_snapshot": {
             "type": "string",
             "description": "The source snapshot to create this disk."
@@ -185,10 +192,13 @@ An example of extra specs json would look like this:
     "nic_type": "VIRTIO_NET",
     "custom_labels": {"environment":"production","project":"myproject"},
     "network_tags": ["web-server", "production"],
+    "service_accounts": [{"email":"email@email.com", "scopes":["https://www.googleapis.com/auth/devstorage.read_only", "https://www.googleapis.com/auth/logging.write"]}],
     "source_snapshot": "projects/garm-testing/global/snapshots/garm-snapshot",
     "ssh_keys": ["username1:ssh_key1", "username2:ssh_key2"]
 }
 ```
+
+**NOTE**: Using the `service_accounts` extra specs when creating instances **introduces certain risks that must be carefully managed**. **Service accounts** grant access to specific resources, and if improperly configured, they can expose sensitive data or allow unauthorized actions. Misconfigured permissions or overly broad scopes can lead to privilege escalation, enabling attackers or unintended users to access critical resources. It's essential to follow the principle of least privilege, ensuring that service accounts only have the necessary permissions for their intended tasks. Regular audits and proper key management are also crucial to safeguard access and prevent potential security vulnerabilities.
 
 **NOTE**: The `custom_labels` and `network_tags` must meet the [GCP requirements for labels](https://cloud.google.com/compute/docs/labeling-resources#requirements) and the [GCP requirements for network tags](https://cloud.google.com/vpc/docs/add-remove-network-tags#restrictions)!
 

--- a/README.md
+++ b/README.md
@@ -104,9 +104,17 @@ To this end, this provider supports the following extra specs schema:
     "type": "object",
     "description": "Schema defining supported extra specs for the Garm GCP Provider",
     "properties": {
+        "display_device": {
+            "type": "boolean",
+            "description": "Enable the display device on the VM."
+        },
         "disksize": {
             "type": "integer",
             "description": "The size of the root disk in GB. Default is 127 GB."
+        },
+        "disktype": {
+            "type": "string",
+            "description": "The type of the disk. Default is pd-standard."
         },
         "network_id": {
             "type": "string",
@@ -169,7 +177,9 @@ An example of extra specs json would look like this:
 
 ```bash
 {
+    "display_device": true,
     "disksize": 255,
+    "disktype": "projects/garm-testing/zones/europe-west1/diskTypes/pd-ssd",
     "network_id": "projects/garm-testing/global/networks/garm-2",
     "subnetwork_id": "projects/garm-testing/regions/europe-west1/subnetworks/garm",
     "nic_type": "VIRTIO_NET",

--- a/internal/client/gcp.go
+++ b/internal/client/gcp.go
@@ -324,13 +324,16 @@ func generateBootDisk(diskSize int64, image, snapshot string, diskType string, c
 			Boot: proto.Bool(true),
 			InitializeParams: &computepb.AttachedDiskInitializeParams{
 				DiskSizeGb:     proto.Int64(diskSize),
-				DiskType:       proto.String(diskType),
 				Labels:         customLabels,
 				SourceImage:    proto.String(image),
 				SourceSnapshot: proto.String(snapshot),
 			},
 			AutoDelete: proto.Bool(true),
 		},
+	}
+
+	if diskType != "" {
+		disk[0].InitializeParams.DiskType = proto.String(diskType)
 	}
 
 	if snapshot != "" {

--- a/internal/client/gcp.go
+++ b/internal/client/gcp.go
@@ -135,7 +135,7 @@ func (g *GcpCli) CreateInstance(ctx context.Context, spec *spec.RunnerSpec) (*co
 	inst := &computepb.Instance{
 		Name:        proto.String(name),
 		MachineType: proto.String(util.GetMachineType(g.cfg.Zone, spec.BootstrapParams.Flavor)),
-		Disks:       generateBootDisk(spec.DiskSize, spec.BootstrapParams.Image, spec.SourceSnapshot),
+		Disks:       generateBootDisk(spec.DiskSize, spec.BootstrapParams.Image, spec.SourceSnapshot, spec.DiskType),
 		NetworkInterfaces: []*computepb.NetworkInterface{
 			{
 				Network: proto.String(g.cfg.NetworkID),
@@ -314,12 +314,14 @@ func selectStartupScript(osType params.OSType) string {
 	}
 }
 
-func generateBootDisk(diskSize int64, image, snapshot string) []*computepb.AttachedDisk {
+func generateBootDisk(diskSize int64, image, snapshot string, diskType string) []*computepb.AttachedDisk {
 	disk := []*computepb.AttachedDisk{
 		{
 			Boot: proto.Bool(true),
 			InitializeParams: &computepb.AttachedDiskInitializeParams{
-				DiskSizeGb:     proto.Int64(diskSize),
+				DiskSizeGb: proto.Int64(diskSize),
+				DiskType:   proto.String(diskType),
+				// Labels:         customLabels,
 				SourceImage:    proto.String(image),
 				SourceSnapshot: proto.String(snapshot),
 			},

--- a/internal/client/gcp.go
+++ b/internal/client/gcp.go
@@ -135,7 +135,7 @@ func (g *GcpCli) CreateInstance(ctx context.Context, spec *spec.RunnerSpec) (*co
 	inst := &computepb.Instance{
 		Name:        proto.String(name),
 		MachineType: proto.String(util.GetMachineType(g.cfg.Zone, spec.BootstrapParams.Flavor)),
-		Disks:       generateBootDisk(spec.DiskSize, spec.BootstrapParams.Image, spec.SourceSnapshot, spec.DiskType),
+		Disks:       generateBootDisk(spec.DiskSize, spec.BootstrapParams.Image, spec.SourceSnapshot, spec.DiskType, spec.CustomLabels),
 		NetworkInterfaces: []*computepb.NetworkInterface{
 			{
 				Network: proto.String(g.cfg.NetworkID),
@@ -314,14 +314,14 @@ func selectStartupScript(osType params.OSType) string {
 	}
 }
 
-func generateBootDisk(diskSize int64, image, snapshot string, diskType string) []*computepb.AttachedDisk {
+func generateBootDisk(diskSize int64, image, snapshot string, diskType string, customLabels map[string]string) []*computepb.AttachedDisk {
 	disk := []*computepb.AttachedDisk{
 		{
 			Boot: proto.Bool(true),
 			InitializeParams: &computepb.AttachedDiskInitializeParams{
-				DiskSizeGb: proto.Int64(diskSize),
-				DiskType:   proto.String(diskType),
-				// Labels:         customLabels,
+				DiskSizeGb:     proto.Int64(diskSize),
+				DiskType:       proto.String(diskType),
+				Labels:         customLabels,
 				SourceImage:    proto.String(image),
 				SourceSnapshot: proto.String(snapshot),
 			},

--- a/internal/client/gcp.go
+++ b/internal/client/gcp.go
@@ -136,6 +136,9 @@ func (g *GcpCli) CreateInstance(ctx context.Context, spec *spec.RunnerSpec) (*co
 		Name:        proto.String(name),
 		MachineType: proto.String(util.GetMachineType(g.cfg.Zone, spec.BootstrapParams.Flavor)),
 		Disks:       generateBootDisk(spec.DiskSize, spec.BootstrapParams.Image, spec.SourceSnapshot, spec.DiskType, spec.CustomLabels),
+		DisplayDevice: &computepb.DisplayDevice{
+			EnableDisplay: proto.Bool(spec.DisplayDevice),
+		},
 		NetworkInterfaces: []*computepb.NetworkInterface{
 			{
 				Network: proto.String(g.cfg.NetworkID),

--- a/internal/client/gcp.go
+++ b/internal/client/gcp.go
@@ -172,6 +172,7 @@ func (g *GcpCli) CreateInstance(ctx context.Context, spec *spec.RunnerSpec) (*co
 		Tags: &computepb.Tags{
 			Items: spec.NetworkTags,
 		},
+		ServiceAccounts: spec.ServiceAccounts,
 	}
 
 	if !g.cfg.ExternalIPAccess {

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -128,7 +128,7 @@ func (e *extraSpecs) Validate() error {
 
 type extraSpecs struct {
 	DiskSize        int64             `json:"disksize,omitempty" jsonschema:"description=The size of the root disk in GB. Default is 127 GB."`
-	DiskType        string            `json:"disktype,omitempty" jsonschema:"description=The type of the disk. Default is pd-ssd."`
+	DiskType        string            `json:"disktype,omitempty" jsonschema:"description=The type of the disk. Default is pd-standard."`
 	DisplayDevice   bool              `json:"display_device,omitempty" jsonschema:"description=Enable the display device on the VM."`
 	NetworkID       string            `json:"network_id,omitempty" jsonschema:"description=The name of the network attached to the instance."`
 	SubnetworkID    string            `json:"subnetwork_id,omitempty" jsonschema:"description=The name of the subnetwork attached to the instance."`

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -128,6 +128,7 @@ func (e *extraSpecs) Validate() error {
 
 type extraSpecs struct {
 	DiskSize        int64             `json:"disksize,omitempty" jsonschema:"description=The size of the root disk in GB. Default is 127 GB."`
+	DiskType        string            `json:"disktype,omitempty" jsonschema:"description=The type of the disk. Default is pd-ssd."`
 	NetworkID       string            `json:"network_id,omitempty" jsonschema:"description=The name of the network attached to the instance."`
 	SubnetworkID    string            `json:"subnetwork_id,omitempty" jsonschema:"description=The name of the subnetwork attached to the instance."`
 	NicType         string            `json:"nic_type,omitempty" jsonschema:"description=The type of the network interface card. Default is VIRTIO_NET."`
@@ -183,6 +184,7 @@ type RunnerSpec struct {
 	ControllerID    string
 	NicType         string
 	DiskSize        int64
+	DiskType        string
 	CustomLabels    map[string]string
 	NetworkTags     []string
 	SourceSnapshot  string
@@ -199,6 +201,9 @@ func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
 	}
 	if extraSpecs.DiskSize > 0 {
 		r.DiskSize = extraSpecs.DiskSize
+	}
+	if extraSpecs.DiskType != "" {
+		r.DiskType = extraSpecs.DiskType
 	}
 	if extraSpecs.NicType != "" {
 		r.NicType = extraSpecs.NicType

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -129,6 +129,7 @@ func (e *extraSpecs) Validate() error {
 type extraSpecs struct {
 	DiskSize        int64             `json:"disksize,omitempty" jsonschema:"description=The size of the root disk in GB. Default is 127 GB."`
 	DiskType        string            `json:"disktype,omitempty" jsonschema:"description=The type of the disk. Default is pd-ssd."`
+	DisplayDevice   bool              `json:"display_device,omitempty" jsonschema:"description=Enable the display device on the VM."`
 	NetworkID       string            `json:"network_id,omitempty" jsonschema:"description=The name of the network attached to the instance."`
 	SubnetworkID    string            `json:"subnetwork_id,omitempty" jsonschema:"description=The name of the subnetwork attached to the instance."`
 	NicType         string            `json:"nic_type,omitempty" jsonschema:"description=The type of the network interface card. Default is VIRTIO_NET."`
@@ -183,6 +184,7 @@ type RunnerSpec struct {
 	SubnetworkID    string
 	ControllerID    string
 	NicType         string
+	DisplayDevice   bool
 	DiskSize        int64
 	DiskType        string
 	CustomLabels    map[string]string
@@ -198,6 +200,9 @@ func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
 	}
 	if extraSpecs.SubnetworkID != "" {
 		r.SubnetworkID = extraSpecs.SubnetworkID
+	}
+	if extraSpecs.DisplayDevice {
+		r.DisplayDevice = extraSpecs.DisplayDevice
 	}
 	if extraSpecs.DiskSize > 0 {
 		r.DiskSize = extraSpecs.DiskSize

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -21,6 +21,7 @@ import (
 	"maps"
 	"regexp"
 
+	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/cloudbase/garm-provider-common/cloudconfig"
 	"github.com/cloudbase/garm-provider-common/params"
 	"github.com/cloudbase/garm-provider-common/util"
@@ -127,17 +128,18 @@ func (e *extraSpecs) Validate() error {
 }
 
 type extraSpecs struct {
-	DiskSize        int64             `json:"disksize,omitempty" jsonschema:"description=The size of the root disk in GB. Default is 127 GB."`
-	DiskType        string            `json:"disktype,omitempty" jsonschema:"description=The type of the disk. Default is pd-standard."`
-	DisplayDevice   bool              `json:"display_device,omitempty" jsonschema:"description=Enable the display device on the VM."`
-	NetworkID       string            `json:"network_id,omitempty" jsonschema:"description=The name of the network attached to the instance."`
-	SubnetworkID    string            `json:"subnetwork_id,omitempty" jsonschema:"description=The name of the subnetwork attached to the instance."`
-	NicType         string            `json:"nic_type,omitempty" jsonschema:"description=The type of the network interface card. Default is VIRTIO_NET."`
-	CustomLabels    map[string]string `json:"custom_labels,omitempty" jsonschema:"description=Custom labels to apply to the instance. Each label is a key-value pair where both key and value are strings."`
-	NetworkTags     []string          `json:"network_tags,omitempty" jsonschema:"description=A list of network tags to be attached to the instance"`
-	SourceSnapshot  string            `json:"source_snapshot,omitempty" jsonschema:"description=The source snapshot to create this disk."`
-	SSHKeys         []string          `json:"ssh_keys,omitempty" jsonschema:"description=A list of SSH keys to be added to the instance. The format is USERNAME:SSH_KEY"`
-	EnableBootDebug *bool             `json:"enable_boot_debug,omitempty" jsonschema:"description=Enable boot debug on the VM."`
+	DiskSize        int64                       `json:"disksize,omitempty" jsonschema:"description=The size of the root disk in GB. Default is 127 GB."`
+	DiskType        string                      `json:"disktype,omitempty" jsonschema:"description=The type of the disk. Default is pd-standard."`
+	DisplayDevice   bool                        `json:"display_device,omitempty" jsonschema:"description=Enable the display device on the VM."`
+	NetworkID       string                      `json:"network_id,omitempty" jsonschema:"description=The name of the network attached to the instance."`
+	SubnetworkID    string                      `json:"subnetwork_id,omitempty" jsonschema:"description=The name of the subnetwork attached to the instance."`
+	NicType         string                      `json:"nic_type,omitempty" jsonschema:"description=The type of the network interface card. Default is VIRTIO_NET."`
+	CustomLabels    map[string]string           `json:"custom_labels,omitempty" jsonschema:"description=Custom labels to apply to the instance. Each label is a key-value pair where both key and value are strings."`
+	NetworkTags     []string                    `json:"network_tags,omitempty" jsonschema:"description=A list of network tags to be attached to the instance"`
+	ServiceAccounts []*computepb.ServiceAccount `json:"service_accounts,omitempty" jsonschema:"description=A list of service accounts to be attached to the instance"`
+	SourceSnapshot  string                      `json:"source_snapshot,omitempty" jsonschema:"description=The source snapshot to create this disk."`
+	SSHKeys         []string                    `json:"ssh_keys,omitempty" jsonschema:"description=A list of SSH keys to be added to the instance. The format is USERNAME:SSH_KEY"`
+	EnableBootDebug *bool                       `json:"enable_boot_debug,omitempty" jsonschema:"description=Enable boot debug on the VM."`
 	// The Cloudconfig struct from common package
 	cloudconfig.CloudConfigSpec
 }
@@ -189,6 +191,7 @@ type RunnerSpec struct {
 	DiskType        string
 	CustomLabels    map[string]string
 	NetworkTags     []string
+	ServiceAccounts []*computepb.ServiceAccount
 	SourceSnapshot  string
 	SSHKeys         string
 	EnableBootDebug bool
@@ -218,6 +221,9 @@ func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
 	}
 	if len(extraSpecs.NetworkTags) > 0 {
 		r.NetworkTags = extraSpecs.NetworkTags
+	}
+	if len(extraSpecs.ServiceAccounts) > 0 {
+		r.ServiceAccounts = extraSpecs.ServiceAccounts
 	}
 	if extraSpecs.SourceSnapshot != "" {
 		r.SourceSnapshot = extraSpecs.SourceSnapshot

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -67,7 +67,7 @@ func TestJsonSchemaValidation(t *testing.T) {
 		{
 			name: "Specs just with disktype",
 			input: json.RawMessage(`{
-				"disktype": "pd-ssd"
+				"disktype": "projects/garm-testing/zones/europe-west1/diskTypes/pd-ssd"
 			}`),
 			errString: "",
 		},
@@ -275,8 +275,9 @@ func TestMergeExtraSpecs(t *testing.T) {
 			extraSpecs: &extraSpecs{
 				NetworkID:       "projects/garm-testing/global/networks/garm-2",
 				SubnetworkID:    "projects/garm-testing/regions/europe-west1/subnetworks/garm",
+				DisplayDevice:   true,
 				DiskSize:        100,
-				DiskType:        "pd-ssd",
+				DiskType:        "projects/garm-testing/zones/europe-west1/diskTypes/pd-ssd",
 				NicType:         "VIRTIO_NET",
 				CustomLabels:    map[string]string{"key1": "value1"},
 				NetworkTags:     []string{"tag1", "tag2"},
@@ -296,8 +297,9 @@ func TestMergeExtraSpecs(t *testing.T) {
 			spec := &RunnerSpec{
 				NetworkID:      "default-network",
 				SubnetworkID:   "default-subnetwork",
+				DisplayDevice:  true,
 				DiskSize:       50,
-				DiskType:       "pd-standard",
+				DiskType:       "projects/garm-testing/zones/europe-west1/diskTypes/pd-ssd",
 				NicType:        "Standard",
 				CustomLabels:   map[string]string{"key2": "value2"},
 				NetworkTags:    []string{"tag3", "tag4"},

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -34,6 +34,7 @@ func TestJsonSchemaValidation(t *testing.T) {
 			name: "Full specs",
 			input: json.RawMessage(`{
 				"disksize": 127,
+				"disktype": "pd-ssd",
 				"network_id": "default",
 				"subnetwork_id": "default",
 				"nic_type": "VIRTIO_NET",
@@ -52,6 +53,13 @@ func TestJsonSchemaValidation(t *testing.T) {
 			name: "Specs just with disksize",
 			input: json.RawMessage(`{
 				"disksize": 127
+			}`),
+			errString: "",
+		},
+		{
+			name: "Specs just with disktype",
+			input: json.RawMessage(`{
+				"disktype": "pd-ssd"
 			}`),
 			errString: "",
 		},
@@ -144,6 +152,13 @@ func TestJsonSchemaValidation(t *testing.T) {
 				"disksize": "127"
 			}`),
 			errString: "schema validation failed: [disksize: Invalid type. Expected: integer, given: string]",
+		},
+		{
+			name: "Invalid input for disktype - wrong data type",
+			input: json.RawMessage(`{
+				"disktype": 127
+			}`),
+			errString: "schema validation failed: [disktype: Invalid type. Expected: string, given: integer]",
 		},
 		{
 			name: "Invalid input for nic_type - wrong data type",
@@ -246,6 +261,7 @@ func TestMergeExtraSpecs(t *testing.T) {
 				NetworkID:       "projects/garm-testing/global/networks/garm-2",
 				SubnetworkID:    "projects/garm-testing/regions/europe-west1/subnetworks/garm",
 				DiskSize:        100,
+				DiskType:        "pd-ssd",
 				NicType:         "VIRTIO_NET",
 				CustomLabels:    map[string]string{"key1": "value1"},
 				NetworkTags:     []string{"tag1", "tag2"},
@@ -266,6 +282,7 @@ func TestMergeExtraSpecs(t *testing.T) {
 				NetworkID:      "default-network",
 				SubnetworkID:   "default-subnetwork",
 				DiskSize:       50,
+				DiskType:       "pd-standard",
 				NicType:        "Standard",
 				CustomLabels:   map[string]string{"key2": "value2"},
 				NetworkTags:    []string{"tag3", "tag4"},
@@ -285,6 +302,11 @@ func TestMergeExtraSpecs(t *testing.T) {
 			if tt.extraSpecs.DiskSize != 0 {
 				if spec.DiskSize != tt.extraSpecs.DiskSize {
 					assert.Equal(t, tt.extraSpecs.DiskSize, spec.DiskSize, "expected DiskSize to be %d, got %d", tt.extraSpecs.DiskSize, spec.DiskSize)
+				}
+			}
+			if tt.extraSpecs.DiskType != "" {
+				if spec.DiskType != tt.extraSpecs.DiskType {
+					assert.Equal(t, tt.extraSpecs.DiskType, spec.DiskType, "expected DiskType to be %s, got %s", tt.extraSpecs.DiskType, spec.DiskType)
 				}
 			}
 			if tt.extraSpecs.NicType != "" {

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -33,6 +33,7 @@ func TestJsonSchemaValidation(t *testing.T) {
 		{
 			name: "Full specs",
 			input: json.RawMessage(`{
+				"display_device": true,
 				"disksize": 127,
 				"disktype": "pd-ssd",
 				"network_id": "default",
@@ -47,6 +48,13 @@ func TestJsonSchemaValidation(t *testing.T) {
 				"enable_boot_debug": true,
 				"runner_install_template": "IyEvYmluL2Jhc2gKZWNobyBJbnN0YWxsaW5nIHJ1bm5lci4uLg==", "pre_install_scripts": {"setup.sh": "IyEvYmluL2Jhc2gKZWNobyBTZXR1cCBzY3JpcHQuLi4="}, "extra_context": {"key": "value"}
 				}`),
+			errString: "",
+		},
+		{
+			name: "Specs just with display_device",
+			input: json.RawMessage(`{
+				"display_device": true
+			}`),
 			errString: "",
 		},
 		{
@@ -145,6 +153,13 @@ func TestJsonSchemaValidation(t *testing.T) {
 				}
 			}`),
 			errString: "",
+		},
+		{
+			name: "Invalid input for display_device - wrong data type",
+			input: json.RawMessage(`{
+				"display_device": "true"
+			}`),
+			errString: "schema validation failed: [display_device: Invalid type. Expected: boolean, given: string]",
 		},
 		{
 			name: "Invalid input for disksize - wrong data type",


### PR DESCRIPTION
- Adding the `DiskType` extra-specs option
- Adding the `customLabels` to the Disk as well
- Adding the `DisplayDevice` extra-specs option
- Adding the `ServiceAccounts` extra-specs option
- Updating the current json-schema with the new extra-specs
- Updating Readme.md regarding the new extra-specs
- Adding Warning regarding using the `service_accounts` option on a Runner
- Updating current tests with the new extra-specs options

Fixes: #31 