### PR TITLE
add support for disable_updates in extra_specs for the garm gcp provider.

### DIFF
--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -140,6 +140,7 @@ type extraSpecs struct {
 	SourceSnapshot  string                      `json:"source_snapshot,omitempty" jsonschema:"description=The source snapshot to create this disk."`
 	SSHKeys         []string                    `json:"ssh_keys,omitempty" jsonschema:"description=A list of SSH keys to be added to the instance. The format is USERNAME:SSH_KEY"`
 	EnableBootDebug *bool                       `json:"enable_boot_debug,omitempty" jsonschema:"description=Enable boot debug on the VM."`
+	DisableUpdates        *bool                  `json:"disable_updates,omitempty" jsonschema:"description=Disable OS updates on boot."`
 	// The Cloudconfig struct from common package
 	cloudconfig.CloudConfigSpec
 }
@@ -195,6 +196,7 @@ type RunnerSpec struct {
 	SourceSnapshot  string
 	SSHKeys         string
 	EnableBootDebug bool
+	DisableUpdates  bool
 }
 
 func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
@@ -236,6 +238,9 @@ func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
 	if extraSpecs.EnableBootDebug != nil {
 		r.EnableBootDebug = *extraSpecs.EnableBootDebug
 	}
+	if extraSpecs.DisableUpdates != nil {
+		r.DisableUpdates = *extraSpecs.DisableUpdates
+	}
 }
 
 func (r *RunnerSpec) Validate() error {
@@ -260,6 +265,7 @@ func (r *RunnerSpec) Validate() error {
 func (r RunnerSpec) ComposeUserData() (string, error) {
 	bootstrapParams := r.BootstrapParams
 	bootstrapParams.UserDataOptions.EnableBootDebug = r.EnableBootDebug
+	bootstrapParams.UserDataOptions.DisableUpdatesOnBoot = r.DisableUpdates
 
 	switch r.BootstrapParams.OSType {
 	case params.Linux:

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -140,7 +140,7 @@ type extraSpecs struct {
 	SourceSnapshot  string                      `json:"source_snapshot,omitempty" jsonschema:"description=The source snapshot to create this disk."`
 	SSHKeys         []string                    `json:"ssh_keys,omitempty" jsonschema:"description=A list of SSH keys to be added to the instance. The format is USERNAME:SSH_KEY"`
 	EnableBootDebug *bool                       `json:"enable_boot_debug,omitempty" jsonschema:"description=Enable boot debug on the VM."`
-	DisableUpdates        *bool                  `json:"disable_updates,omitempty" jsonschema:"description=Disable OS updates on boot."`
+	DisableUpdates  *bool                       `json:"disable_updates,omitempty" jsonschema:"description=Disable OS updates on boot."`
 	// The Cloudconfig struct from common package
 	cloudconfig.CloudConfigSpec
 }

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -354,16 +354,16 @@ func TestMergeExtraSpecs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			spec := &RunnerSpec{
-				NetworkID:      "default-network",
-				DisableUpdates: false, // Default value
-				SubnetworkID:   "default-subnetwork",
-				DisplayDevice:  true,
-				DiskSize:       50,
-				DiskType:       "projects/garm-testing/zones/europe-west1/diskTypes/pd-ssd",
-				NicType:        "Standard",
-				CustomLabels:   map[string]string{"key2": "value2"},
-				NetworkTags:    []string{"tag3", "tag4"},
-				SourceSnapshot: "default-snapshot",
+				NetworkID:       "default-network",
+				DisableUpdates:  false, // Default value
+				SubnetworkID:    "default-subnetwork",
+				DisplayDevice:   true,
+				DiskSize:        50,
+				DiskType:        "projects/garm-testing/zones/europe-west1/diskTypes/pd-ssd",
+				NicType:         "Standard",
+				CustomLabels:    map[string]string{"key2": "value2"},
+				NetworkTags:     []string{"tag3", "tag4"},
+				SourceSnapshot:  "default-snapshot",
 				EnableBootDebug: false, // Default value
 			}
 			spec.MergeExtraSpecs(tt.extraSpecs)
@@ -412,7 +412,7 @@ func TestMergeExtraSpecs(t *testing.T) {
 				expectedEnableBootDebug = *tt.extraSpecs.EnableBootDebug
 			}
 			assert.Equal(t, expectedEnableBootDebug, spec.EnableBootDebug, "expected EnableBootDebug to be %t, got %t", expectedEnableBootDebug, spec.EnableBootDebug)
-			
+
 			expectedDisableUpdates := false // Default for RunnerSpec.DisableUpdates
 			if tt.extraSpecs.DisableUpdates != nil {
 				expectedDisableUpdates = *tt.extraSpecs.DisableUpdates

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -308,7 +308,6 @@ func TestMergeExtraSpecs(t *testing.T) {
 	enable_boot_debug := true
 	tests := []struct {
 		name       string
-		name       string
 		extraSpecs *extraSpecs
 	}{
 		{
@@ -330,26 +329,20 @@ func TestMergeExtraSpecs(t *testing.T) {
 				},
 				SourceSnapshot:  "projects/garm-testing/global/snapshots/garm-snapshot",
 				SSHKeys:         []string{"ssh-key1", "ssh-key2"},
-				CloudConfigSpec: cloudconfig.CloudConfigSpec{
-					EnableBootDebug: &enable_boot_debug,
-					DisableUpdates:  proto.Bool(true),
-				},
+				EnableBootDebug: &enable_boot_debug,
+				DisableUpdates:  proto.Bool(true),
 			},
 		},
 		{
 			name: "ValidExtraSpecsWithDisableUpdatesFalse",
 			extraSpecs: &extraSpecs{
-				CloudConfigSpec: cloudconfig.CloudConfigSpec{
-					DisableUpdates: proto.Bool(false),
-				},
+				DisableUpdates: proto.Bool(false),
 			},
 		},
 		{
 			name: "ValidExtraSpecsWithEnableBootDebugFalse",
 			extraSpecs: &extraSpecs{
-				CloudConfigSpec: cloudconfig.CloudConfigSpec{
-					EnableBootDebug: proto.Bool(false),
-				},
+				EnableBootDebug: proto.Bool(false),
 			},
 		},
 		{
@@ -415,16 +408,14 @@ func TestMergeExtraSpecs(t *testing.T) {
 			}
 			// Check EnableBootDebug from embedded CloudConfigSpec or direct field if overridden
 			expectedEnableBootDebug := spec.EnableBootDebug // Keep default if not set in extraSpecs
-			if tt.extraSpecs.EnableBootDebug != nil { // Direct field in extraSpecs takes precedence
+			if tt.extraSpecs.EnableBootDebug != nil {
 				expectedEnableBootDebug = *tt.extraSpecs.EnableBootDebug
-			} else if tt.extraSpecs.CloudConfigSpec.EnableBootDebug != nil {
-				expectedEnableBootDebug = *tt.extraSpecs.CloudConfigSpec.EnableBootDebug
 			}
 			assert.Equal(t, expectedEnableBootDebug, spec.EnableBootDebug, "expected EnableBootDebug to be %t, got %t", expectedEnableBootDebug, spec.EnableBootDebug)
 			
 			expectedDisableUpdates := false // Default for RunnerSpec.DisableUpdates
-			if tt.extraSpecs.CloudConfigSpec.DisableUpdates != nil {
-				expectedDisableUpdates = *tt.extraSpecs.CloudConfigSpec.DisableUpdates
+			if tt.extraSpecs.DisableUpdates != nil {
+				expectedDisableUpdates = *tt.extraSpecs.DisableUpdates
 			}
 			assert.Equal(t, expectedDisableUpdates, spec.DisableUpdates, "expected DisableUpdates to be %t, got %t", expectedDisableUpdates, spec.DisableUpdates)
 		})


### PR DESCRIPTION
support for disable_updates was missing for the gcp runners.

I was able to confirm that the user-data now contains:

```
package_upgrade: false
```
