### PR TITLE
feat: add opt-in regional runner placement

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,12 +34,13 @@ func NewConfig(cfgFile string) (*Config, error) {
 }
 
 type Config struct {
-	ProjectId        string `toml:"project_id"`
-	Zone             string `toml:"zone"`
-	CredentialsFile  string `toml:"credentials_file"`
-	NetworkID        string `toml:"network_id"`
-	SubnetworkID     string `toml:"subnetwork_id"`
-	ExternalIPAccess bool   `toml:"external_ip_access"`
+	ProjectId               string `toml:"project_id"`
+	Zone                    string `toml:"zone"`
+	CredentialsFile         string `toml:"credentials_file"`
+	NetworkID               string `toml:"network_id"`
+	SubnetworkID            string `toml:"subnetwork_id"`
+	ExternalIPAccess        bool   `toml:"external_ip_access"`
+	EnableRegionalPlacement bool   `toml:"enable_regional_placement"`
 }
 
 func (c *Config) Validate() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -107,6 +107,7 @@ func TestNewConfig(t *testing.T) {
 	subnetwork_id = "projects/garm-testing/regions/europe-west1/subnetworks/garm"
 	credentials_file = "/home/ubuntu/service-account-key.json"
 	external_ip_access = true
+	enable_regional_placement = true
 	`
 	// Create a temporary file
 	tmpFile, err := os.CreateTemp("", "config-*.toml")
@@ -132,4 +133,5 @@ func TestNewConfig(t *testing.T) {
 	require.Equal(t, "projects/garm-testing/regions/europe-west1/subnetworks/garm", cfg.SubnetworkID, "SubnetworkId value did not match expected")
 	require.Equal(t, "/home/ubuntu/service-account-key.json", cfg.CredentialsFile, "CredentialsFile value did not match expected")
 	require.Equal(t, true, cfg.ExternalIPAccess, "ExternalIpAccess value did not match expected")
+	require.True(t, cfg.EnableRegionalPlacement, "EnableRegionalPlacement value did not match expected")
 }

--- a/internal/client/gcp.go
+++ b/internal/client/gcp.go
@@ -41,8 +41,9 @@ const (
 )
 
 var (
-	WaitOp = (*compute.Operation).Wait
-	NextIt = (*compute.InstanceIterator).Next
+	WaitOp           = (*compute.Operation).Wait
+	NextIt           = (*compute.InstanceIterator).Next
+	NextAggregatedIt = (*compute.InstancesScopedListPairIterator).Next
 )
 
 func getHTTPClientOptionFromCredentialsFile(ctx context.Context, credentialsFile string) (option.ClientOption, error) {
@@ -86,6 +87,14 @@ func NewGcpCli(ctx context.Context, cfg *config.Config) (*GcpCli, error) {
 		cfg:    cfg,
 		client: computeClient,
 	}
+	if cfg.EnableRegionalPlacement {
+		regionClient, err := compute.NewRegionInstancesRESTClient(ctx, authOptions...)
+		if err != nil {
+			_ = computeClient.Close()
+			return nil, fmt.Errorf("error creating regional compute service: %w", err)
+		}
+		gcpCli.regionClient = regionClient
+	}
 
 	return gcpCli, nil
 }
@@ -97,11 +106,17 @@ type ClientInterface interface {
 	Delete(ctx context.Context, req *computepb.DeleteInstanceRequest, opts ...gax.CallOption) (*compute.Operation, error)
 	List(ctx context.Context, req *computepb.ListInstancesRequest, opts ...gax.CallOption) *compute.InstanceIterator
 	Get(ctx context.Context, req *computepb.GetInstanceRequest, opts ...gax.CallOption) (*computepb.Instance, error)
+	AggregatedList(ctx context.Context, req *computepb.AggregatedListInstancesRequest, opts ...gax.CallOption) *compute.InstancesScopedListPairIterator
+}
+
+type RegionalClientInterface interface {
+	BulkInsert(ctx context.Context, req *computepb.BulkInsertRegionInstanceRequest, opts ...gax.CallOption) (*compute.Operation, error)
 }
 
 type GcpCli struct {
-	cfg    *config.Config
-	client ClientInterface
+	cfg          *config.Config
+	client       ClientInterface
+	regionClient RegionalClientInterface
 }
 
 func (g GcpCli) Config() *config.Config {
@@ -114,6 +129,10 @@ func (g GcpCli) Client() ClientInterface {
 
 func (g *GcpCli) SetClient(client ClientInterface) {
 	g.client = client
+}
+
+func (g *GcpCli) SetRegionalClient(client RegionalClientInterface) {
+	g.regionClient = client
 }
 
 func (g *GcpCli) SetConfig(cfg *config.Config) {
@@ -194,6 +213,9 @@ func (g *GcpCli) CreateInstance(ctx context.Context, spec *spec.RunnerSpec) (*co
 			Value: proto.String("googet -noconfirm=true install google-compute-engine-ssh"),
 		})
 	}
+	if spec.RegionalPlacement != nil {
+		return g.createRegionalInstance(ctx, spec, inst)
+	}
 
 	insertReq := &computepb.InsertInstanceRequest{
 		Project:          g.cfg.ProjectId,
@@ -214,6 +236,15 @@ func (g *GcpCli) CreateInstance(ctx context.Context, spec *spec.RunnerSpec) (*co
 }
 
 func (g *GcpCli) GetInstance(ctx context.Context, instanceName string) (*computepb.Instance, error) {
+	if g.cfg.EnableRegionalPlacement {
+		if zone, name, ok := splitRegionalProviderID(instanceName); ok {
+			instance, err := g.getInstanceInZone(ctx, zone, name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get regional instance: %w", err)
+			}
+			return instance, nil
+		}
+	}
 	req := &computepb.GetInstanceRequest{
 		Project:  g.cfg.ProjectId,
 		Zone:     g.cfg.Zone,
@@ -245,15 +276,40 @@ func (g *GcpCli) ListDescribedInstances(ctx context.Context, poolID string) ([]*
 		}
 		instances = append(instances, instance)
 	}
+	if g.cfg.EnableRegionalPlacement {
+		regional, err := g.listRegionalInstances(ctx, poolID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list regional instances: %w", err)
+		}
+		seen := make(map[string]struct{}, len(instances))
+		for _, instance := range instances {
+			seen[util.GetInstanceName(instance.GetName())] = struct{}{}
+		}
+		for _, instance := range regional {
+			if _, ok := seen[util.GetInstanceName(instance.GetName())]; ok {
+				continue
+			}
+			instances = append(instances, instance)
+		}
+	}
 
 	return instances, nil
 }
 
 func (g *GcpCli) DeleteInstance(ctx context.Context, instance string) error {
+	if g.cfg.EnableRegionalPlacement {
+		if zone, name, ok := splitRegionalProviderID(instance); ok {
+			return g.deleteInstanceInZone(ctx, zone, name)
+		}
+	}
+	return g.deleteInstanceInZone(ctx, g.cfg.Zone, instance)
+}
+
+func (g *GcpCli) deleteInstanceInZone(ctx context.Context, zone, instance string) error {
 	req := &computepb.DeleteInstanceRequest{
 		Instance: util.GetInstanceName(instance),
 		Project:  g.cfg.ProjectId,
-		Zone:     g.cfg.Zone,
+		Zone:     zone,
 	}
 
 	op, err := g.client.Delete(ctx, req)
@@ -275,10 +331,18 @@ func (g *GcpCli) DeleteInstance(ctx context.Context, instance string) error {
 }
 
 func (g *GcpCli) StopInstance(ctx context.Context, instance string) error {
+	zone := g.cfg.Zone
+	name := instance
+	if g.cfg.EnableRegionalPlacement {
+		if regionalZone, regionalName, ok := splitRegionalProviderID(instance); ok {
+			zone = regionalZone
+			name = regionalName
+		}
+	}
 	req := &computepb.StopInstanceRequest{
-		Instance: util.GetInstanceName(instance),
+		Instance: util.GetInstanceName(name),
 		Project:  g.cfg.ProjectId,
-		Zone:     g.cfg.Zone,
+		Zone:     zone,
 	}
 
 	op, err := g.client.Stop(ctx, req)
@@ -294,10 +358,18 @@ func (g *GcpCli) StopInstance(ctx context.Context, instance string) error {
 }
 
 func (g *GcpCli) StartInstance(ctx context.Context, instance string) error {
+	zone := g.cfg.Zone
+	name := instance
+	if g.cfg.EnableRegionalPlacement {
+		if regionalZone, regionalName, ok := splitRegionalProviderID(instance); ok {
+			zone = regionalZone
+			name = regionalName
+		}
+	}
 	req := &computepb.StartInstanceRequest{
-		Instance: util.GetInstanceName(instance),
+		Instance: util.GetInstanceName(name),
 		Project:  g.cfg.ProjectId,
-		Zone:     g.cfg.Zone,
+		Zone:     zone,
 	}
 
 	op, err := g.client.Start(ctx, req)

--- a/internal/client/mock_client.go
+++ b/internal/client/mock_client.go
@@ -56,5 +56,21 @@ func (m *MockGcpClient) List(ctx context.Context, req *computepb.ListInstancesRe
 
 func (m *MockGcpClient) Get(ctx context.Context, req *computepb.GetInstanceRequest, opts ...gax.CallOption) (*computepb.Instance, error) {
 	args := m.Called(ctx, req, opts)
-	return args.Get(0).(*computepb.Instance), args.Error(1)
+	instance, _ := args.Get(0).(*computepb.Instance)
+	return instance, args.Error(1)
+}
+
+func (m *MockGcpClient) AggregatedList(ctx context.Context, req *computepb.AggregatedListInstancesRequest, opts ...gax.CallOption) *compute.InstancesScopedListPairIterator {
+	args := m.Called(ctx, req, opts)
+	return args.Get(0).(*compute.InstancesScopedListPairIterator)
+}
+
+type MockRegionalGcpClient struct {
+	mock.Mock
+}
+
+func (m *MockRegionalGcpClient) BulkInsert(ctx context.Context, req *computepb.BulkInsertRegionInstanceRequest, opts ...gax.CallOption) (*compute.Operation, error) {
+	args := m.Called(ctx, req, opts)
+	operation, _ := args.Get(0).(*compute.Operation)
+	return operation, args.Error(1)
 }

--- a/internal/client/regional_placement.go
+++ b/internal/client/regional_placement.go
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Cloudbase Solutions SRL
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/cloudbase/garm-provider-gcp/internal/spec"
+	"github.com/cloudbase/garm-provider-gcp/internal/util"
+	"google.golang.org/api/iterator"
+	"google.golang.org/protobuf/proto"
+)
+
+const RegionalPlacementLabel = "garmregionalplacement"
+
+var (
+	ambiguousCreateLookupTimeout  = 30 * time.Second
+	ambiguousCreateLookupInterval = time.Second
+)
+
+func (g *GcpCli) createRegionalInstance(ctx context.Context, runnerSpec *spec.RunnerSpec, inst *computepb.Instance) (*computepb.Instance, error) {
+	if g.regionClient == nil {
+		return nil, fmt.Errorf("regional placement client is not configured")
+	}
+	markRegionalInstance(inst)
+	existing, err := g.findInstanceInZones(ctx, inst.GetName(), runnerSpec.RegionalPlacement.Zones)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check for existing regional instance %q: %w", inst.GetName(), err)
+	}
+	if existing != nil {
+		if err := validateRegionalInstanceIdentity(existing, inst); err != nil {
+			return nil, fmt.Errorf("existing regional instance %q does not match this runner: %w", inst.GetName(), err)
+		}
+		return existing, nil
+	}
+
+	req, err := buildRegionalInsertRequest(g.cfg.ProjectId, runnerSpec, inst)
+	if err != nil {
+		return nil, err
+	}
+	op, err := g.regionClient.BulkInsert(ctx, req)
+	if err == nil {
+		err = WaitOp(op, ctx)
+	}
+	if err != nil {
+		if !isAmbiguousCreateError(err) {
+			return nil, fmt.Errorf("failed to create regional instance: %w", err)
+		}
+		lookupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), ambiguousCreateLookupTimeout)
+		defer cancel()
+		created, lookupErr := g.waitForInstanceInZones(lookupCtx, inst.GetName(), runnerSpec.RegionalPlacement.Zones)
+		if lookupErr != nil {
+			return nil, fmt.Errorf("failed to reconcile regional create error %w: %w", err, lookupErr)
+		}
+		if created == nil {
+			return nil, fmt.Errorf("regional create result is ambiguous: %w", err)
+		}
+		if identityErr := validateRegionalInstanceIdentity(created, inst); identityErr != nil {
+			return nil, fmt.Errorf("regional create returned a mismatched instance: %w", identityErr)
+		}
+		return created, nil
+	}
+
+	created, err := g.findInstanceInZones(ctx, inst.GetName(), runnerSpec.RegionalPlacement.Zones)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve created regional instance %q: %w", inst.GetName(), err)
+	}
+	if created == nil {
+		return nil, fmt.Errorf("regional bulk insert completed without instance %q", inst.GetName())
+	}
+	if err := validateRegionalInstanceIdentity(created, inst); err != nil {
+		return nil, fmt.Errorf("regional create returned a mismatched instance: %w", err)
+	}
+	return created, nil
+}
+
+func buildRegionalInsertRequest(project string, runnerSpec *spec.RunnerSpec, inst *computepb.Instance) (*computepb.BulkInsertRegionInstanceRequest, error) {
+	requestID, err := newRequestID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate request ID: %w", err)
+	}
+	disks := make([]*computepb.AttachedDisk, 0, len(inst.Disks))
+	for _, disk := range inst.Disks {
+		cloned := proto.Clone(disk).(*computepb.AttachedDisk)
+		if cloned.InitializeParams != nil {
+			cloned.InitializeParams.SourceSnapshot = nil
+		}
+		disks = append(disks, cloned)
+	}
+	zones := make([]*computepb.LocationPolicyZoneConfiguration, 0, len(runnerSpec.RegionalPlacement.Zones))
+	for _, zone := range runnerSpec.RegionalPlacement.Zones {
+		zones = append(zones, &computepb.LocationPolicyZoneConfiguration{Zone: proto.String("zones/" + zone)})
+	}
+	one := int64(1)
+	return &computepb.BulkInsertRegionInstanceRequest{
+		Project:   project,
+		Region:    runnerSpec.RegionalPlacement.Region(),
+		RequestId: proto.String(requestID),
+		BulkInsertInstanceResourceResource: &computepb.BulkInsertInstanceResource{
+			Count:    &one,
+			MinCount: &one,
+			LocationPolicy: &computepb.LocationPolicy{
+				TargetShape: proto.String("ANY_SINGLE_ZONE"),
+				Zones:       zones,
+			},
+			InstanceProperties: &computepb.InstanceProperties{
+				MachineType:            proto.String(runnerSpec.BootstrapParams.Flavor),
+				Disks:                  disks,
+				Labels:                 inst.Labels,
+				Metadata:               inst.Metadata,
+				NetworkInterfaces:      inst.NetworkInterfaces,
+				ServiceAccounts:        inst.ServiceAccounts,
+				ShieldedInstanceConfig: inst.ShieldedInstanceConfig,
+				Tags:                   inst.Tags,
+			},
+			PerInstanceProperties: map[string]*computepb.BulkInsertInstanceResourcePerInstanceProperties{
+				inst.GetName(): {},
+			},
+		},
+	}, nil
+}
+
+func markRegionalInstance(inst *computepb.Instance) {
+	if inst.Labels == nil {
+		inst.Labels = make(map[string]string)
+	}
+	inst.Labels[RegionalPlacementLabel] = "true"
+}
+
+func validateRegionalInstanceIdentity(existing, expected *computepb.Instance) error {
+	if existing.GetName() != expected.GetName() {
+		return fmt.Errorf("name is %q, expected %q", existing.GetName(), expected.GetName())
+	}
+	if existing.Labels[RegionalPlacementLabel] != "true" {
+		return fmt.Errorf("regional placement marker is missing")
+	}
+	for key, value := range expected.Labels {
+		if existing.Labels[key] != value {
+			return fmt.Errorf("label %q is %q, expected %q", key, existing.Labels[key], value)
+		}
+	}
+	return nil
+}
+
+func splitRegionalProviderID(providerID string) (zone, name string, ok bool) {
+	zone, name, ok = strings.Cut(providerID, "/")
+	if !ok || zone == "" || name == "" || strings.Contains(name, "/") {
+		return "", "", false
+	}
+	return strings.ToLower(zone), util.GetInstanceName(name), true
+}
+
+func (g *GcpCli) getInstanceInZone(ctx context.Context, zone, name string) (*computepb.Instance, error) {
+	instance, err := g.client.Get(ctx, &computepb.GetInstanceRequest{
+		Project: g.cfg.ProjectId, Zone: zone, Instance: util.GetInstanceName(name),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if instance != nil && instance.Zone == nil {
+		instance.Zone = proto.String("zones/" + zone)
+	}
+	return instance, nil
+}
+
+func (g *GcpCli) findInstanceInZones(ctx context.Context, name string, zones []string) (*computepb.Instance, error) {
+	var found *computepb.Instance
+	for _, zone := range zones {
+		instance, err := g.getInstanceInZone(ctx, zone, name)
+		if err != nil {
+			if isRegionalNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to search zone %q: %w", zone, err)
+		}
+		if instance == nil {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf("instance name %q exists in multiple zones", name)
+		}
+		found = instance
+	}
+	return found, nil
+}
+
+func (g *GcpCli) waitForInstanceInZones(ctx context.Context, name string, zones []string) (*computepb.Instance, error) {
+	for {
+		instance, err := g.findInstanceInZones(ctx, name, zones)
+		if err != nil || instance != nil {
+			return instance, err
+		}
+		timer := time.NewTimer(ambiguousCreateLookupInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, nil
+		case <-timer.C:
+		}
+	}
+}
+
+func (g *GcpCli) listRegionalInstances(ctx context.Context, poolID string) ([]*computepb.Instance, error) {
+	filter := fmt.Sprintf("labels.garmpoolid=%s AND labels.%s=true", poolID, RegionalPlacementLabel)
+	partial := true
+	it := g.client.AggregatedList(ctx, &computepb.AggregatedListInstancesRequest{
+		Project: g.cfg.ProjectId, Filter: &filter, ReturnPartialSuccess: &partial,
+	})
+	var instances []*computepb.Instance
+	for {
+		pair, err := NextAggregatedIt(it)
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if pair.Value == nil {
+			continue
+		}
+		for _, instance := range pair.Value.Instances {
+			if instance.Labels[RegionalPlacementLabel] != "true" {
+				continue
+			}
+			if instance.Zone == nil && strings.HasPrefix(pair.Key, "zones/") {
+				instance.Zone = proto.String(pair.Key)
+			}
+			instances = append(instances, instance)
+		}
+	}
+	return instances, nil
+}
+
+func isRegionalNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "not found") || strings.Contains(message, "notfound") || strings.Contains(message, "code = 404")
+}
+
+func isAmbiguousCreateError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	for _, reason := range []string{"unexpected eof", "connection reset", "transport is closing", "client connection lost"} {
+		if strings.Contains(message, reason) {
+			return true
+		}
+	}
+	return false
+}
+
+func newRequestID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", err
+	}
+	value[6] = (value[6] & 0x0f) | 0x40
+	value[8] = (value[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", value[0:4], value[4:6], value[6:8], value[8:10], value[10:16]), nil
+}

--- a/internal/client/regional_placement_test.go
+++ b/internal/client/regional_placement_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Cloudbase Solutions SRL
+
+package client
+
+import (
+	"testing"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/cloudbase/garm-provider-common/params"
+	"github.com/cloudbase/garm-provider-gcp/internal/spec"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestBuildRegionalInsertRequestUsesExistingPoolShape(t *testing.T) {
+	runnerSpec := &spec.RunnerSpec{
+		RegionalPlacement: &spec.RegionalPlacement{Zones: []string{"us-central1-a", "us-central1-b"}},
+		BootstrapParams: params.BootstrapInstance{
+			Name: "runner-one", Flavor: "n2d-standard-4", Image: "projects/example/global/images/runner",
+		},
+	}
+	instance := &computepb.Instance{
+		Name:   proto.String("runner-one"),
+		Labels: map[string]string{"garmpoolid": "pool-one"},
+		Disks: []*computepb.AttachedDisk{{
+			Boot: proto.Bool(true),
+			InitializeParams: &computepb.AttachedDiskInitializeParams{
+				SourceImage: proto.String("projects/example/global/images/runner"),
+				// The legacy builder emits this empty field. The regional request must not.
+				SourceSnapshot: proto.String(""),
+			},
+		}},
+		NetworkInterfaces: []*computepb.NetworkInterface{{Network: proto.String("network")}},
+	}
+	markRegionalInstance(instance)
+
+	req, err := buildRegionalInsertRequest("project-one", runnerSpec, instance)
+	require.NoError(t, err)
+	require.Equal(t, "us-central1", req.Region)
+	require.NotEmpty(t, req.GetRequestId())
+	resource := req.BulkInsertInstanceResourceResource
+	require.EqualValues(t, 1, resource.GetCount())
+	require.EqualValues(t, 1, resource.GetMinCount())
+	require.Equal(t, "ANY_SINGLE_ZONE", resource.LocationPolicy.GetTargetShape())
+	require.Len(t, resource.LocationPolicy.Zones, 2)
+	require.Equal(t, "n2d-standard-4", resource.InstanceProperties.GetMachineType())
+	require.Nil(t, resource.InstanceFlexibilityPolicy)
+	require.Equal(t, "projects/example/global/images/runner", resource.InstanceProperties.Disks[0].InitializeParams.GetSourceImage())
+	require.Nil(t, resource.InstanceProperties.Disks[0].InitializeParams.SourceSnapshot)
+	require.Equal(t, "true", resource.InstanceProperties.Labels[RegionalPlacementLabel])
+	require.Contains(t, resource.PerInstanceProperties, "runner-one")
+}
+
+func TestSplitRegionalProviderID(t *testing.T) {
+	zone, name, ok := splitRegionalProviderID("US-CENTRAL1-B/Runner-One")
+	require.True(t, ok)
+	require.Equal(t, "us-central1-b", zone)
+	require.Equal(t, "runner-one", name)
+
+	_, _, ok = splitRegionalProviderID("legacy-runner")
+	require.False(t, ok)
+}

--- a/internal/spec/regional_placement.go
+++ b/internal/spec/regional_placement.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Cloudbase Solutions SRL
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spec
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RegionalPlacement allows Compute Engine to choose a zone for a runner while
+// preserving the pool's existing machine type and instance properties.
+type RegionalPlacement struct {
+	Zones []string `json:"zones" jsonschema:"description=Compute Engine zones allowed for regional placement."`
+}
+
+func (p *RegionalPlacement) Validate() error {
+	if p == nil {
+		return nil
+	}
+	if len(p.Zones) == 0 {
+		return fmt.Errorf("regional_placement.zones must not be empty")
+	}
+
+	region := ""
+	seen := make(map[string]struct{}, len(p.Zones))
+	for _, zone := range p.Zones {
+		zoneRegion, err := regionFromZone(zone)
+		if err != nil {
+			return fmt.Errorf("invalid regional placement zone %q: %w", zone, err)
+		}
+		if region == "" {
+			region = zoneRegion
+		} else if region != zoneRegion {
+			return fmt.Errorf("regional placement zones must belong to one region")
+		}
+		if _, ok := seen[zone]; ok {
+			return fmt.Errorf("duplicate regional placement zone %q", zone)
+		}
+		seen[zone] = struct{}{}
+	}
+	return nil
+}
+
+func (p *RegionalPlacement) Region() string {
+	if p == nil || len(p.Zones) == 0 {
+		return ""
+	}
+	region, _ := regionFromZone(p.Zones[0])
+	return region
+}
+
+func regionFromZone(zone string) (string, error) {
+	lastDash := strings.LastIndex(zone, "-")
+	suffix := zone[lastDash+1:]
+	if lastDash <= 0 || len(suffix) != 1 || suffix[0] < 'a' || suffix[0] > 'z' {
+		return "", fmt.Errorf("expected a zone name with a hyphen-delimited suffix")
+	}
+	return zone[:lastDash], nil
+}

--- a/internal/spec/regional_placement_test.go
+++ b/internal/spec/regional_placement_test.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Cloudbase Solutions SRL
+
+package spec
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cloudbase/garm-provider-common/params"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegionalPlacementValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  *RegionalPlacement
+		wantErr string
+	}{
+		{name: "valid", policy: &RegionalPlacement{Zones: []string{"us-central1-a", "us-central1-b"}}},
+		{name: "empty", policy: &RegionalPlacement{}, wantErr: "regional_placement.zones must not be empty"},
+		{name: "duplicate", policy: &RegionalPlacement{Zones: []string{"us-central1-a", "us-central1-a"}}, wantErr: `duplicate regional placement zone "us-central1-a"`},
+		{name: "cross region", policy: &RegionalPlacement{Zones: []string{"us-central1-a", "us-east1-b"}}, wantErr: "regional placement zones must belong to one region"},
+		{name: "malformed", policy: &RegionalPlacement{Zones: []string{"us-central1"}}, wantErr: "expected a zone name with a hyphen-delimited suffix"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.policy.Validate()
+			if test.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, test.wantErr)
+		})
+	}
+}
+
+func TestRegionalPlacementExtraSpecsAreAdditive(t *testing.T) {
+	extra, err := newExtraSpecsFromBootstrapData(params.BootstrapInstance{ExtraSpecs: json.RawMessage(`{
+		"regional_placement": {"zones": ["us-central1-a", "us-central1-b"]}
+	}`)})
+	require.NoError(t, err)
+	require.Equal(t, "us-central1", extra.RegionalPlacement.Region())
+}
+
+func TestRegionalPlacementRejectsUnsupportedExistingOptions(t *testing.T) {
+	policy := &RegionalPlacement{Zones: []string{"us-central1-a"}}
+	require.ErrorContains(t, (&extraSpecs{RegionalPlacement: policy, DisplayDevice: true}).Validate(), "display_device")
+	require.ErrorContains(t, (&extraSpecs{RegionalPlacement: policy, SourceSnapshot: "snapshot"}).Validate(), "source_snapshot")
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -92,6 +92,20 @@ func newExtraSpecsFromBootstrapData(data params.BootstrapInstance) (*extraSpecs,
 }
 
 func (e *extraSpecs) Validate() error {
+	if e.RegionalPlacement != nil {
+		if e.DisplayDevice {
+			return fmt.Errorf("regional_placement cannot be combined with display_device")
+		}
+		if e.SourceSnapshot != "" {
+			return fmt.Errorf("regional_placement cannot be combined with source_snapshot")
+		}
+		if len(e.CustomLabels) > 60 {
+			return fmt.Errorf("regional placement custom labels cannot exceed 60 items")
+		}
+		if err := e.RegionalPlacement.Validate(); err != nil {
+			return err
+		}
+	}
 	if len(e.CustomLabels) > 61 {
 		return fmt.Errorf("custom labels cannot exceed 61 items")
 	}
@@ -128,19 +142,20 @@ func (e *extraSpecs) Validate() error {
 }
 
 type extraSpecs struct {
-	DiskSize        int64                       `json:"disksize,omitempty" jsonschema:"description=The size of the root disk in GB. Default is 127 GB."`
-	DiskType        string                      `json:"disktype,omitempty" jsonschema:"description=The type of the disk. Default is pd-standard."`
-	DisplayDevice   bool                        `json:"display_device,omitempty" jsonschema:"description=Enable the display device on the VM."`
-	NetworkID       string                      `json:"network_id,omitempty" jsonschema:"description=The name of the network attached to the instance."`
-	SubnetworkID    string                      `json:"subnetwork_id,omitempty" jsonschema:"description=The name of the subnetwork attached to the instance."`
-	NicType         string                      `json:"nic_type,omitempty" jsonschema:"description=The type of the network interface card. Default is VIRTIO_NET."`
-	CustomLabels    map[string]string           `json:"custom_labels,omitempty" jsonschema:"description=Custom labels to apply to the instance. Each label is a key-value pair where both key and value are strings."`
-	NetworkTags     []string                    `json:"network_tags,omitempty" jsonschema:"description=A list of network tags to be attached to the instance"`
-	ServiceAccounts []*computepb.ServiceAccount `json:"service_accounts,omitempty" jsonschema:"description=A list of service accounts to be attached to the instance"`
-	SourceSnapshot  string                      `json:"source_snapshot,omitempty" jsonschema:"description=The source snapshot to create this disk."`
-	SSHKeys         []string                    `json:"ssh_keys,omitempty" jsonschema:"description=A list of SSH keys to be added to the instance. The format is USERNAME:SSH_KEY"`
-	EnableBootDebug *bool                       `json:"enable_boot_debug,omitempty" jsonschema:"description=Enable boot debug on the VM."`
-	DisableUpdates  *bool                       `json:"disable_updates,omitempty" jsonschema:"description=Disable OS updates on boot."`
+	RegionalPlacement *RegionalPlacement          `json:"regional_placement,omitempty" jsonschema:"description=Optional regional placement using the pool's existing flavor and image."`
+	DiskSize          int64                       `json:"disksize,omitempty" jsonschema:"description=The size of the root disk in GB. Default is 127 GB."`
+	DiskType          string                      `json:"disktype,omitempty" jsonschema:"description=The type of the disk. Default is pd-standard."`
+	DisplayDevice     bool                        `json:"display_device,omitempty" jsonschema:"description=Enable the display device on the VM."`
+	NetworkID         string                      `json:"network_id,omitempty" jsonschema:"description=The name of the network attached to the instance."`
+	SubnetworkID      string                      `json:"subnetwork_id,omitempty" jsonschema:"description=The name of the subnetwork attached to the instance."`
+	NicType           string                      `json:"nic_type,omitempty" jsonschema:"description=The type of the network interface card. Default is VIRTIO_NET."`
+	CustomLabels      map[string]string           `json:"custom_labels,omitempty" jsonschema:"description=Custom labels to apply to the instance. Each label is a key-value pair where both key and value are strings."`
+	NetworkTags       []string                    `json:"network_tags,omitempty" jsonschema:"description=A list of network tags to be attached to the instance"`
+	ServiceAccounts   []*computepb.ServiceAccount `json:"service_accounts,omitempty" jsonschema:"description=A list of service accounts to be attached to the instance"`
+	SourceSnapshot    string                      `json:"source_snapshot,omitempty" jsonschema:"description=The source snapshot to create this disk."`
+	SSHKeys           []string                    `json:"ssh_keys,omitempty" jsonschema:"description=A list of SSH keys to be added to the instance. The format is USERNAME:SSH_KEY"`
+	EnableBootDebug   *bool                       `json:"enable_boot_debug,omitempty" jsonschema:"description=Enable boot debug on the VM."`
+	DisableUpdates    *bool                       `json:"disable_updates,omitempty" jsonschema:"description=Disable OS updates on boot."`
 	// Shielded VM options
 	EnableSecureBoot          bool `json:"enable_secure_boot,omitempty" jsonschema:"description=Enable Secure Boot on the VM. Requires a Shielded VM compatible image."`
 	EnableVTPM                bool `json:"enable_vtpm,omitempty" jsonschema:"description=Enable virtual Trusted Platform Module (vTPM) on the VM."`
@@ -169,40 +184,48 @@ func GetRunnerSpecFromBootstrapParams(cfg *config.Config, data params.BootstrapI
 	}
 
 	spec := &RunnerSpec{
-		Zone:            cfg.Zone,
-		Tools:           tools,
-		BootstrapParams: data,
-		NetworkID:       cfg.NetworkID,
-		SubnetworkID:    cfg.SubnetworkID,
-		ControllerID:    controllerID,
-		NicType:         defaultNicType,
-		DiskSize:        defaultDiskSizeGB,
-		CustomLabels:    labels,
+		RegionalPlacementEnabled: cfg.EnableRegionalPlacement,
+		Zone:                     cfg.Zone,
+		Tools:                    tools,
+		BootstrapParams:          data,
+		NetworkID:                cfg.NetworkID,
+		SubnetworkID:             cfg.SubnetworkID,
+		ControllerID:             controllerID,
+		NicType:                  defaultNicType,
+		DiskSize:                 defaultDiskSizeGB,
+		CustomLabels:             labels,
 	}
 
 	spec.MergeExtraSpecs(extraSpecs)
+	if spec.RegionalPlacement != nil {
+		if err := spec.Validate(); err != nil {
+			return nil, fmt.Errorf("failed to validate regional runner spec: %w", err)
+		}
+	}
 
 	return spec, nil
 }
 
 type RunnerSpec struct {
-	Zone            string
-	Tools           params.RunnerApplicationDownload
-	BootstrapParams params.BootstrapInstance
-	NetworkID       string
-	SubnetworkID    string
-	ControllerID    string
-	NicType         string
-	DisplayDevice   bool
-	DiskSize        int64
-	DiskType        string
-	CustomLabels    map[string]string
-	NetworkTags     []string
-	ServiceAccounts []*computepb.ServiceAccount
-	SourceSnapshot  string
-	SSHKeys         string
-	EnableBootDebug bool
-	DisableUpdates  bool
+	RegionalPlacement        *RegionalPlacement
+	RegionalPlacementEnabled bool
+	Zone                     string
+	Tools                    params.RunnerApplicationDownload
+	BootstrapParams          params.BootstrapInstance
+	NetworkID                string
+	SubnetworkID             string
+	ControllerID             string
+	NicType                  string
+	DisplayDevice            bool
+	DiskSize                 int64
+	DiskType                 string
+	CustomLabels             map[string]string
+	NetworkTags              []string
+	ServiceAccounts          []*computepb.ServiceAccount
+	SourceSnapshot           string
+	SSHKeys                  string
+	EnableBootDebug          bool
+	DisableUpdates           bool
 	// Shielded VM options
 	EnableSecureBoot          bool
 	EnableVTPM                bool
@@ -212,6 +235,7 @@ type RunnerSpec struct {
 }
 
 func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
+	r.RegionalPlacement = extraSpecs.RegionalPlacement
 	if extraSpecs.NetworkID != "" {
 		r.NetworkID = extraSpecs.NetworkID
 	}
@@ -268,6 +292,9 @@ func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
 }
 
 func (r *RunnerSpec) Validate() error {
+	if r.RegionalPlacement != nil && !r.RegionalPlacementEnabled {
+		return fmt.Errorf("regional placement is disabled by provider configuration")
+	}
 	if r.Zone == "" {
 		return fmt.Errorf("missing zone")
 	}
@@ -282,6 +309,9 @@ func (r *RunnerSpec) Validate() error {
 	}
 	if r.NicType == "" {
 		return fmt.Errorf("missing nic type")
+	}
+	if err := r.RegionalPlacement.Validate(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -23,6 +23,8 @@ import (
 	"github.com/cloudbase/garm-provider-common/params"
 )
 
+const RegionalPlacementLabel = "garmregionalplacement"
+
 func GetMachineType(zone, flavor string) string {
 	machine := fmt.Sprintf("zones/%s/machineTypes/%s", zone, flavor)
 	return machine
@@ -31,6 +33,25 @@ func GetMachineType(zone, flavor string) string {
 func GetInstanceName(name string) string {
 	lowerName := strings.ToLower(name)
 	return lowerName
+}
+
+func GetZoneName(zone string) string {
+	parts := strings.Split(strings.TrimSuffix(zone, "/"), "/")
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[len(parts)-1]
+}
+
+func GetRegionalProviderID(instance *computepb.Instance) (string, error) {
+	if instance == nil || instance.Labels[RegionalPlacementLabel] != "true" {
+		return "", fmt.Errorf("instance is not marked for regional placement")
+	}
+	zone := GetZoneName(instance.GetZone())
+	if zone == "" {
+		return "", fmt.Errorf("regional instance zone is missing")
+	}
+	return zone + "/" + GetInstanceName(instance.GetName()), nil
 }
 
 func getNameForInstance(instance *computepb.Instance) (string, error) {
@@ -66,11 +87,36 @@ func GcpInstanceToParamsInstance(gcpInstance *computepb.Instance) (params.Provid
 		return params.ProviderInstance{}, fmt.Errorf("instance name is nil")
 	}
 
-	details := params.ProviderInstance{
-		ProviderID: GetInstanceName(*gcpInstance.Name),
-		Name:       name,
-		OSType:     params.OSType(gcpInstance.Labels["ostype"]),
-		OSArch:     params.OSArch(*gcpInstance.Disks[0].Architecture),
+	var details params.ProviderInstance
+	if gcpInstance.Labels[RegionalPlacementLabel] == "true" {
+		providerID, err := GetRegionalProviderID(gcpInstance)
+		if err != nil {
+			return params.ProviderInstance{}, err
+		}
+		if len(gcpInstance.GetDisks()) == 0 || gcpInstance.GetDisks()[0].Architecture == nil {
+			return params.ProviderInstance{}, fmt.Errorf("regional instance boot disk architecture is missing")
+		}
+		details = params.ProviderInstance{
+			ProviderID: providerID,
+			Name:       name,
+			OSType:     params.OSType(gcpInstance.Labels["ostype"]),
+		}
+		switch strings.ToUpper(gcpInstance.Disks[0].GetArchitecture()) {
+		case "AMD64", "X86_64":
+			details.OSArch = params.Amd64
+		case "ARM64":
+			details.OSArch = params.Arm64
+		default:
+			return params.ProviderInstance{}, fmt.Errorf("unsupported regional instance architecture %q", gcpInstance.Disks[0].GetArchitecture())
+		}
+	} else {
+		// Preserve the legacy conversion exactly for unmarked zonal instances.
+		details = params.ProviderInstance{
+			ProviderID: GetInstanceName(*gcpInstance.Name),
+			Name:       name,
+			OSType:     params.OSType(gcpInstance.Labels["ostype"]),
+			OSArch:     params.OSArch(*gcpInstance.Disks[0].Architecture),
+		}
 	}
 
 	switch gcpInstance.GetStatus() {

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -71,6 +71,23 @@ func TestGcpInstanceToParamsInstance(t *testing.T) {
 			errString: "",
 		},
 		{
+			name: "Regional instance uses zoned ID without changing legacy conversion",
+			gcpInstance: &computepb.Instance{
+				Name:   proto.String("garm-instance"),
+				Zone:   proto.String("zones/us-central1-b"),
+				Labels: map[string]string{"ostype": "linux", RegionalPlacementLabel: "true"},
+				Disks:  []*computepb.AttachedDisk{{Architecture: proto.String("X86_64")}},
+				Status: proto.String("RUNNING"),
+			},
+			expected: params.ProviderInstance{
+				ProviderID: "us-central1-b/garm-instance",
+				Name:       "garm-instance",
+				OSType:     "linux",
+				OSArch:     params.Amd64,
+				Status:     "running",
+			},
+		},
+		{
 			name:        "NilGcpInstance",
 			gcpInstance: nil,
 			expected:    params.ProviderInstance{},

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -69,6 +69,13 @@ func (g *GcpProvider) CreateInstance(ctx context.Context, bootstrapParams params
 		OSArch:     spec.BootstrapParams.OSArch,
 		Status:     "running",
 	}
+	if spec.RegionalPlacement != nil {
+		providerID, err := util.GetRegionalProviderID(inst)
+		if err != nil {
+			return params.ProviderInstance{}, fmt.Errorf("failed to get regional provider ID: %w", err)
+		}
+		instance.ProviderID = providerID
+	}
 	return instance, nil
 }
 


### PR DESCRIPTION
## Summary

- add opt-in regional placement using Compute Engine regional bulk insert
- keep the existing pool flavor, image, disk, network, and Standard provisioning behavior
- add zoned lifecycle handling only for newly marked regional instances

## Scope

This PR implements one capability only: allowing Compute Engine to choose one of an explicitly allowed set of zones in a region.

It deliberately does not include ranked machine types, Spot provisioning, Spot-to-Standard fallback, per-candidate overrides, legacy bare-ID migration, or README changes. Those are separate changes.

## Backward compatibility

- the provider capability is disabled by default
- without regional_placement, the existing zonal create/get/list/delete/start/stop paths remain unchanged
- legacy provider IDs and OSArch conversion remain unchanged
- the regional client and aggregate discovery are used only after provider-level opt-in

## Validation

- go test -mod=vendor ./...
- go vet -mod=vendor ./...
- go test -race -mod=vendor ./...

## Draft status

Draft pending maintainer feedback on the additive config/extra-spec names and a real-GCP regional bulk-insert smoke test.