### PR TITLE
Add opt-in regional runner placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ subnetwork_id = "projects/garm-testing/regions/europe-west1/subnetworks/garm"
 # Leave this empty if you want to use the default credentials.
 credentials_file = "/home/ubuntu/service-account-key.json"
 external_ip_access = true
+# Set this to true if you want to allow pools to opt into regional
+# placement via the regional_placement extra spec.
+enable_regional_placement = false
 ```
 
 NOTE: If you want to pass in credentials by using the `GOOGLE_APPLICATION_CREDENTIALS` environment variable, you can leave the `credentials_file` field empty, but you must pass in the variable to GARM, then in the GARM config file, you must specify that the `GOOGLE_APPLICATION_CREDENTIALS` is safe to pass to the provider by setting the `environment_variables` field to `["GOOGLE_APPLICATION_CREDENTIALS"]`:
@@ -190,6 +193,19 @@ To this end, this provider supports the following extra specs schema:
             "additionalProperties": {
                 "type": "string"
             }
+        },
+        "regional_placement": {
+            "type": "object",
+            "description": "Optional regional placement using the pool's existing flavor and image.",
+            "properties": {
+                "zones": {
+                    "type": "array",
+                    "description": "Compute Engine zones allowed for regional placement. All zones must belong to one region.",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
         }
     },
     "additionalProperties": false
@@ -219,6 +235,8 @@ An example of extra specs json would look like this:
 **NOTE**: The `custom_labels` and `network_tags` must meet the [GCP requirements for labels](https://cloud.google.com/compute/docs/labeling-resources#requirements) and the [GCP requirements for network tags](https://cloud.google.com/vpc/docs/add-remove-network-tags#restrictions)!
 
 **NOTE**: The `ssh_keys` add the option to [connect to an instance via SSH](https://cloud.google.com/compute/docs/instances/ssh) (either Linux or Windows). After you added the key as `username:ssh_public_key`, you can use the `private_key` to connect to the Linux/Windows instance via `ssh -i private_rsa username@instance_ip`. For **Windows** instances, the provider installs on the instance `google-compute-engine-ssh` and `enables ssh` if a `ssh_key` is added to extra-specs.
+
+**NOTE**: The `regional_placement` extra spec lets Compute Engine pick one of the allowed zones for each runner, using a [regional bulk insert](https://cloud.google.com/compute/docs/instances/multiple/create-in-bulk). It requires `enable_regional_placement = true` in the provider config and cannot be combined with `display_device` or `source_snapshot`. Runners created this way get a `zone/instance-name` provider ID, so the provider can manage them in whichever zone they landed in.
 
 To set it on an existing pool, simply run:
 

--- a/config/config.go
+++ b/config/config.go
@@ -34,12 +34,13 @@ func NewConfig(cfgFile string) (*Config, error) {
 }
 
 type Config struct {
-	ProjectId        string `toml:"project_id"`
-	Zone             string `toml:"zone"`
-	CredentialsFile  string `toml:"credentials_file"`
-	NetworkID        string `toml:"network_id"`
-	SubnetworkID     string `toml:"subnetwork_id"`
-	ExternalIPAccess bool   `toml:"external_ip_access"`
+	ProjectId               string `toml:"project_id"`
+	Zone                    string `toml:"zone"`
+	CredentialsFile         string `toml:"credentials_file"`
+	NetworkID               string `toml:"network_id"`
+	SubnetworkID            string `toml:"subnetwork_id"`
+	ExternalIPAccess        bool   `toml:"external_ip_access"`
+	EnableRegionalPlacement bool   `toml:"enable_regional_placement"`
 }
 
 func (c *Config) Validate() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -107,6 +107,7 @@ func TestNewConfig(t *testing.T) {
 	subnetwork_id = "projects/garm-testing/regions/europe-west1/subnetworks/garm"
 	credentials_file = "/home/ubuntu/service-account-key.json"
 	external_ip_access = true
+	enable_regional_placement = true
 	`
 	// Create a temporary file
 	tmpFile, err := os.CreateTemp("", "config-*.toml")
@@ -132,4 +133,5 @@ func TestNewConfig(t *testing.T) {
 	require.Equal(t, "projects/garm-testing/regions/europe-west1/subnetworks/garm", cfg.SubnetworkID, "SubnetworkId value did not match expected")
 	require.Equal(t, "/home/ubuntu/service-account-key.json", cfg.CredentialsFile, "CredentialsFile value did not match expected")
 	require.Equal(t, true, cfg.ExternalIPAccess, "ExternalIpAccess value did not match expected")
+	require.Equal(t, true, cfg.EnableRegionalPlacement, "EnableRegionalPlacement value did not match expected")
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/compute v1.64.0
 	github.com/BurntSushi/toml v1.6.0
 	github.com/cloudbase/garm-provider-common v0.1.9
+	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.23.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/stretchr/testify v1.11.1
@@ -27,7 +28,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.17 // indirect
 	github.com/gorilla/handlers v1.5.2 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect

--- a/internal/client/gcp.go
+++ b/internal/client/gcp.go
@@ -41,8 +41,9 @@ const (
 )
 
 var (
-	WaitOp = (*compute.Operation).Wait
-	NextIt = (*compute.InstanceIterator).Next
+	WaitOp           = (*compute.Operation).Wait
+	NextIt           = (*compute.InstanceIterator).Next
+	NextAggregatedIt = (*compute.InstancesScopedListPairIterator).Next
 )
 
 func getHTTPClientOptionFromCredentialsFile(ctx context.Context, credentialsFile string) (option.ClientOption, error) {
@@ -86,6 +87,14 @@ func NewGcpCli(ctx context.Context, cfg *config.Config) (*GcpCli, error) {
 		cfg:    cfg,
 		client: computeClient,
 	}
+	if cfg.EnableRegionalPlacement {
+		regionClient, err := compute.NewRegionInstancesRESTClient(ctx, authOptions...)
+		if err != nil {
+			_ = computeClient.Close()
+			return nil, fmt.Errorf("error creating regional compute service: %w", err)
+		}
+		gcpCli.regionClient = regionClient
+	}
 
 	return gcpCli, nil
 }
@@ -97,11 +106,17 @@ type ClientInterface interface {
 	Delete(ctx context.Context, req *computepb.DeleteInstanceRequest, opts ...gax.CallOption) (*compute.Operation, error)
 	List(ctx context.Context, req *computepb.ListInstancesRequest, opts ...gax.CallOption) *compute.InstanceIterator
 	Get(ctx context.Context, req *computepb.GetInstanceRequest, opts ...gax.CallOption) (*computepb.Instance, error)
+	AggregatedList(ctx context.Context, req *computepb.AggregatedListInstancesRequest, opts ...gax.CallOption) *compute.InstancesScopedListPairIterator
+}
+
+type RegionalClientInterface interface {
+	BulkInsert(ctx context.Context, req *computepb.BulkInsertRegionInstanceRequest, opts ...gax.CallOption) (*compute.Operation, error)
 }
 
 type GcpCli struct {
-	cfg    *config.Config
-	client ClientInterface
+	cfg          *config.Config
+	client       ClientInterface
+	regionClient RegionalClientInterface
 }
 
 func (g GcpCli) Config() *config.Config {
@@ -114,6 +129,10 @@ func (g GcpCli) Client() ClientInterface {
 
 func (g *GcpCli) SetClient(client ClientInterface) {
 	g.client = client
+}
+
+func (g *GcpCli) SetRegionalClient(client RegionalClientInterface) {
+	g.regionClient = client
 }
 
 func (g *GcpCli) SetConfig(cfg *config.Config) {
@@ -194,6 +213,9 @@ func (g *GcpCli) CreateInstance(ctx context.Context, spec *spec.RunnerSpec) (*co
 			Value: proto.String("googet -noconfirm=true install google-compute-engine-ssh"),
 		})
 	}
+	if spec.RegionalPlacement != nil {
+		return g.createRegionalInstance(ctx, spec, inst)
+	}
 
 	insertReq := &computepb.InsertInstanceRequest{
 		Project:          g.cfg.ProjectId,
@@ -214,6 +236,15 @@ func (g *GcpCli) CreateInstance(ctx context.Context, spec *spec.RunnerSpec) (*co
 }
 
 func (g *GcpCli) GetInstance(ctx context.Context, instanceName string) (*computepb.Instance, error) {
+	if g.cfg.EnableRegionalPlacement {
+		if zone, name, ok := splitRegionalProviderID(instanceName); ok {
+			instance, err := g.getInstanceInZone(ctx, zone, name)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get regional instance: %w", err)
+			}
+			return instance, nil
+		}
+	}
 	req := &computepb.GetInstanceRequest{
 		Project:  g.cfg.ProjectId,
 		Zone:     g.cfg.Zone,
@@ -245,15 +276,40 @@ func (g *GcpCli) ListDescribedInstances(ctx context.Context, poolID string) ([]*
 		}
 		instances = append(instances, instance)
 	}
+	if g.cfg.EnableRegionalPlacement {
+		regional, err := g.listRegionalInstances(ctx, poolID)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list regional instances: %w", err)
+		}
+		seen := make(map[string]struct{}, len(instances))
+		for _, instance := range instances {
+			seen[util.GetInstanceName(instance.GetName())] = struct{}{}
+		}
+		for _, instance := range regional {
+			if _, ok := seen[util.GetInstanceName(instance.GetName())]; ok {
+				continue
+			}
+			instances = append(instances, instance)
+		}
+	}
 
 	return instances, nil
 }
 
 func (g *GcpCli) DeleteInstance(ctx context.Context, instance string) error {
+	if g.cfg.EnableRegionalPlacement {
+		if zone, name, ok := splitRegionalProviderID(instance); ok {
+			return g.deleteInstanceInZone(ctx, zone, name)
+		}
+	}
+	return g.deleteInstanceInZone(ctx, g.cfg.Zone, instance)
+}
+
+func (g *GcpCli) deleteInstanceInZone(ctx context.Context, zone, instance string) error {
 	req := &computepb.DeleteInstanceRequest{
 		Instance: util.GetInstanceName(instance),
 		Project:  g.cfg.ProjectId,
-		Zone:     g.cfg.Zone,
+		Zone:     zone,
 	}
 
 	op, err := g.client.Delete(ctx, req)
@@ -275,10 +331,18 @@ func (g *GcpCli) DeleteInstance(ctx context.Context, instance string) error {
 }
 
 func (g *GcpCli) StopInstance(ctx context.Context, instance string) error {
+	zone := g.cfg.Zone
+	name := instance
+	if g.cfg.EnableRegionalPlacement {
+		if regionalZone, regionalName, ok := splitRegionalProviderID(instance); ok {
+			zone = regionalZone
+			name = regionalName
+		}
+	}
 	req := &computepb.StopInstanceRequest{
-		Instance: util.GetInstanceName(instance),
+		Instance: util.GetInstanceName(name),
 		Project:  g.cfg.ProjectId,
-		Zone:     g.cfg.Zone,
+		Zone:     zone,
 	}
 
 	op, err := g.client.Stop(ctx, req)
@@ -294,10 +358,18 @@ func (g *GcpCli) StopInstance(ctx context.Context, instance string) error {
 }
 
 func (g *GcpCli) StartInstance(ctx context.Context, instance string) error {
+	zone := g.cfg.Zone
+	name := instance
+	if g.cfg.EnableRegionalPlacement {
+		if regionalZone, regionalName, ok := splitRegionalProviderID(instance); ok {
+			zone = regionalZone
+			name = regionalName
+		}
+	}
 	req := &computepb.StartInstanceRequest{
-		Instance: util.GetInstanceName(instance),
+		Instance: util.GetInstanceName(name),
 		Project:  g.cfg.ProjectId,
-		Zone:     g.cfg.Zone,
+		Zone:     zone,
 	}
 
 	op, err := g.client.Start(ctx, req)

--- a/internal/client/mock_client.go
+++ b/internal/client/mock_client.go
@@ -58,3 +58,18 @@ func (m *MockGcpClient) Get(ctx context.Context, req *computepb.GetInstanceReque
 	args := m.Called(ctx, req, opts)
 	return args.Get(0).(*computepb.Instance), args.Error(1)
 }
+
+func (m *MockGcpClient) AggregatedList(ctx context.Context, req *computepb.AggregatedListInstancesRequest, opts ...gax.CallOption) *compute.InstancesScopedListPairIterator {
+	args := m.Called(ctx, req, opts)
+	return args.Get(0).(*compute.InstancesScopedListPairIterator)
+}
+
+// MockRegionalGcpClient is a mock of the RegionalClientInterface
+type MockRegionalGcpClient struct {
+	mock.Mock
+}
+
+func (m *MockRegionalGcpClient) BulkInsert(ctx context.Context, req *computepb.BulkInsertRegionInstanceRequest, opts ...gax.CallOption) (*compute.Operation, error) {
+	args := m.Called(ctx, req, opts)
+	return args.Get(0).(*compute.Operation), args.Error(1)
+}

--- a/internal/client/regional_placement.go
+++ b/internal/client/regional_placement.go
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Cloudbase Solutions SRL
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/cloudbase/garm-provider-gcp/internal/spec"
+	"github.com/cloudbase/garm-provider-gcp/internal/util"
+	"github.com/google/uuid"
+	"github.com/googleapis/gax-go/v2/apierror"
+	"google.golang.org/api/iterator"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	regionalTargetShape string = "ANY_SINGLE_ZONE"
+
+	ambiguousCreateLookupTimeout  = 30 * time.Second
+	ambiguousCreateLookupInterval = time.Second
+)
+
+func (g *GcpCli) createRegionalInstance(ctx context.Context, runnerSpec *spec.RunnerSpec, inst *computepb.Instance) (*computepb.Instance, error) {
+	if g.regionClient == nil {
+		return nil, fmt.Errorf("regional placement client is not configured")
+	}
+	markRegionalInstance(inst)
+	existing, err := g.findInstanceInZones(ctx, inst.GetName(), runnerSpec.RegionalPlacement.Zones)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check for existing regional instance %s: %w", inst.GetName(), err)
+	}
+	if existing != nil {
+		if err := validateRegionalInstanceIdentity(existing, inst); err != nil {
+			return nil, fmt.Errorf("existing regional instance %s does not match this runner: %w", inst.GetName(), err)
+		}
+		return existing, nil
+	}
+
+	req := buildRegionalInsertRequest(g.cfg.ProjectId, runnerSpec, inst)
+	op, err := g.regionClient.BulkInsert(ctx, req)
+	if err == nil {
+		err = WaitOp(op, ctx)
+	}
+	if err != nil {
+		if !isAmbiguousCreateError(err) {
+			return nil, fmt.Errorf("failed to create regional instance: %w", err)
+		}
+		// The request may have succeeded on the GCP side. Look for the instance
+		// before reporting the error, so we don't leak a running instance.
+		lookupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), ambiguousCreateLookupTimeout)
+		defer cancel()
+		created, lookupErr := g.waitForInstanceInZones(lookupCtx, inst.GetName(), runnerSpec.RegionalPlacement.Zones)
+		if lookupErr != nil {
+			return nil, fmt.Errorf("failed to reconcile regional create error %w: %w", err, lookupErr)
+		}
+		if created == nil {
+			return nil, fmt.Errorf("regional create result is ambiguous: %w", err)
+		}
+		if identityErr := validateRegionalInstanceIdentity(created, inst); identityErr != nil {
+			return nil, fmt.Errorf("regional create returned a mismatched instance: %w", identityErr)
+		}
+		return created, nil
+	}
+
+	created, err := g.findInstanceInZones(ctx, inst.GetName(), runnerSpec.RegionalPlacement.Zones)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve created regional instance %s: %w", inst.GetName(), err)
+	}
+	if created == nil {
+		return nil, fmt.Errorf("regional bulk insert completed without instance %s", inst.GetName())
+	}
+	if err := validateRegionalInstanceIdentity(created, inst); err != nil {
+		return nil, fmt.Errorf("regional create returned a mismatched instance: %w", err)
+	}
+	return created, nil
+}
+
+func buildRegionalInsertRequest(project string, runnerSpec *spec.RunnerSpec, inst *computepb.Instance) *computepb.BulkInsertRegionInstanceRequest {
+	disks := make([]*computepb.AttachedDisk, 0, len(inst.Disks))
+	for _, disk := range inst.Disks {
+		cloned := proto.Clone(disk).(*computepb.AttachedDisk)
+		if cloned.InitializeParams != nil {
+			cloned.InitializeParams.SourceSnapshot = nil
+		}
+		disks = append(disks, cloned)
+	}
+	zones := make([]*computepb.LocationPolicyZoneConfiguration, 0, len(runnerSpec.RegionalPlacement.Zones))
+	for _, zone := range runnerSpec.RegionalPlacement.Zones {
+		zones = append(zones, &computepb.LocationPolicyZoneConfiguration{
+			Zone: proto.String("zones/" + zone),
+		})
+	}
+	return &computepb.BulkInsertRegionInstanceRequest{
+		Project:   project,
+		Region:    runnerSpec.RegionalPlacement.Region(),
+		RequestId: proto.String(uuid.NewString()),
+		BulkInsertInstanceResourceResource: &computepb.BulkInsertInstanceResource{
+			Count:    proto.Int64(1),
+			MinCount: proto.Int64(1),
+			LocationPolicy: &computepb.LocationPolicy{
+				TargetShape: proto.String(regionalTargetShape),
+				Zones:       zones,
+			},
+			InstanceProperties: &computepb.InstanceProperties{
+				MachineType:            proto.String(runnerSpec.BootstrapParams.Flavor),
+				Disks:                  disks,
+				Labels:                 inst.Labels,
+				Metadata:               inst.Metadata,
+				NetworkInterfaces:      inst.NetworkInterfaces,
+				ServiceAccounts:        inst.ServiceAccounts,
+				ShieldedInstanceConfig: inst.ShieldedInstanceConfig,
+				Tags:                   inst.Tags,
+			},
+			PerInstanceProperties: map[string]*computepb.BulkInsertInstanceResourcePerInstanceProperties{
+				inst.GetName(): {},
+			},
+		},
+	}
+}
+
+func markRegionalInstance(inst *computepb.Instance) {
+	if inst.Labels == nil {
+		inst.Labels = make(map[string]string)
+	}
+	inst.Labels[util.RegionalPlacementLabel] = "true"
+}
+
+func validateRegionalInstanceIdentity(existing, expected *computepb.Instance) error {
+	if existing.GetName() != expected.GetName() {
+		return fmt.Errorf("name is %s, expected %s", existing.GetName(), expected.GetName())
+	}
+	if existing.Labels[util.RegionalPlacementLabel] != "true" {
+		return fmt.Errorf("regional placement marker is missing")
+	}
+	for key, value := range expected.Labels {
+		if existing.Labels[key] != value {
+			return fmt.Errorf("label %s is %s, expected %s", key, existing.Labels[key], value)
+		}
+	}
+	return nil
+}
+
+func splitRegionalProviderID(providerID string) (string, string, bool) {
+	zone, name, ok := strings.Cut(providerID, "/")
+	if !ok || zone == "" || name == "" || strings.Contains(name, "/") {
+		return "", "", false
+	}
+	return strings.ToLower(zone), util.GetInstanceName(name), true
+}
+
+func (g *GcpCli) getInstanceInZone(ctx context.Context, zone, name string) (*computepb.Instance, error) {
+	req := &computepb.GetInstanceRequest{
+		Project:  g.cfg.ProjectId,
+		Zone:     zone,
+		Instance: util.GetInstanceName(name),
+	}
+
+	instance, err := g.client.Get(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	if instance != nil && instance.Zone == nil {
+		instance.Zone = proto.String("zones/" + zone)
+	}
+	return instance, nil
+}
+
+func (g *GcpCli) findInstanceInZones(ctx context.Context, name string, zones []string) (*computepb.Instance, error) {
+	var found *computepb.Instance
+	for _, zone := range zones {
+		instance, err := g.getInstanceInZone(ctx, zone, name)
+		if err != nil {
+			if isRegionalNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to search zone %s: %w", zone, err)
+		}
+		if instance == nil {
+			continue
+		}
+		if found != nil {
+			return nil, fmt.Errorf("instance name %s exists in multiple zones", name)
+		}
+		found = instance
+	}
+	return found, nil
+}
+
+func (g *GcpCli) waitForInstanceInZones(ctx context.Context, name string, zones []string) (*computepb.Instance, error) {
+	for {
+		instance, err := g.findInstanceInZones(ctx, name, zones)
+		if err != nil || instance != nil {
+			return instance, err
+		}
+		timer := time.NewTimer(ambiguousCreateLookupInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, nil
+		case <-timer.C:
+		}
+	}
+}
+
+func (g *GcpCli) listRegionalInstances(ctx context.Context, poolID string) ([]*computepb.Instance, error) {
+	filter := fmt.Sprintf("labels.garmpoolid=%s AND labels.%s=true", poolID, util.RegionalPlacementLabel)
+	req := &computepb.AggregatedListInstancesRequest{
+		Project:              g.cfg.ProjectId,
+		Filter:               &filter,
+		ReturnPartialSuccess: proto.Bool(true),
+	}
+
+	it := g.client.AggregatedList(ctx, req)
+	var instances []*computepb.Instance
+	for {
+		pair, err := NextAggregatedIt(it)
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if pair.Value == nil {
+			continue
+		}
+		for _, instance := range pair.Value.Instances {
+			if instance.Labels[util.RegionalPlacementLabel] != "true" {
+				continue
+			}
+			if instance.Zone == nil && strings.HasPrefix(pair.Key, "zones/") {
+				instance.Zone = proto.String(pair.Key)
+			}
+			instances = append(instances, instance)
+		}
+	}
+	return instances, nil
+}
+
+func isRegionalNotFound(err error) bool {
+	asApiErr, ok := err.(*apierror.APIError)
+	return ok && asApiErr.HTTPCode() == 404
+}
+
+func isAmbiguousCreateError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	for _, reason := range []string{"unexpected eof", "connection reset", "transport is closing", "client connection lost"} {
+		if strings.Contains(message, reason) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/client/regional_placement_test.go
+++ b/internal/client/regional_placement_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Cloudbase Solutions SRL
+//
+//	Licensed under the Apache License, Version 2.0 (the "License"); you may
+//	not use this file except in compliance with the License. You may obtain
+//	a copy of the License at
+//
+//	     http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//	WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//	License for the specific language governing permissions and limitations
+//	under the License.
+
+package client
+
+import (
+	"testing"
+
+	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/cloudbase/garm-provider-common/params"
+	"github.com/cloudbase/garm-provider-gcp/internal/spec"
+	"github.com/cloudbase/garm-provider-gcp/internal/util"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestBuildRegionalInsertRequest(t *testing.T) {
+	runnerSpec := &spec.RunnerSpec{
+		RegionalPlacement: &spec.RegionalPlacement{
+			Zones: []string{"us-central1-a", "us-central1-b"},
+		},
+		BootstrapParams: params.BootstrapInstance{
+			Name:   "garm-instance",
+			Flavor: "n1-standard-1",
+			Image:  "projects/garm-testing/global/images/garm-image",
+		},
+	}
+	instance := &computepb.Instance{
+		Name: proto.String("garm-instance"),
+		Labels: map[string]string{
+			"garmpoolid": "garm-pool",
+		},
+		Disks: []*computepb.AttachedDisk{
+			{
+				Boot: proto.Bool(true),
+				InitializeParams: &computepb.AttachedDiskInitializeParams{
+					SourceImage: proto.String("projects/garm-testing/global/images/garm-image"),
+					// generateBootDisk always sets SourceSnapshot, even when empty.
+					SourceSnapshot: proto.String(""),
+				},
+			},
+		},
+		NetworkInterfaces: []*computepb.NetworkInterface{
+			{
+				Network: proto.String("my-network"),
+			},
+		},
+	}
+	markRegionalInstance(instance)
+
+	req := buildRegionalInsertRequest("my-project", runnerSpec, instance)
+	require.Equal(t, "my-project", req.Project)
+	require.Equal(t, "us-central1", req.Region)
+	require.NotEmpty(t, req.GetRequestId())
+	resource := req.BulkInsertInstanceResourceResource
+	require.EqualValues(t, 1, resource.GetCount())
+	require.EqualValues(t, 1, resource.GetMinCount())
+	require.Equal(t, "ANY_SINGLE_ZONE", resource.LocationPolicy.GetTargetShape())
+	require.Len(t, resource.LocationPolicy.Zones, 2)
+	require.Equal(t, "zones/us-central1-a", resource.LocationPolicy.Zones[0].GetZone())
+	require.Equal(t, "n1-standard-1", resource.InstanceProperties.GetMachineType())
+	require.Equal(t, "projects/garm-testing/global/images/garm-image", resource.InstanceProperties.Disks[0].InitializeParams.GetSourceImage())
+	require.Nil(t, resource.InstanceProperties.Disks[0].InitializeParams.SourceSnapshot)
+	require.Equal(t, "true", resource.InstanceProperties.Labels[util.RegionalPlacementLabel])
+	require.Contains(t, resource.PerInstanceProperties, "garm-instance")
+}
+
+func TestSplitRegionalProviderID(t *testing.T) {
+	tests := []struct {
+		name         string
+		providerID   string
+		expectedZone string
+		expectedName string
+		expectedOk   bool
+	}{
+		{
+			name:         "ZonedProviderID",
+			providerID:   "US-CENTRAL1-B/Garm-Instance",
+			expectedZone: "us-central1-b",
+			expectedName: "garm-instance",
+			expectedOk:   true,
+		},
+		{
+			name:       "PlainInstanceName",
+			providerID: "garm-instance",
+			expectedOk: false,
+		},
+		{
+			name:       "TooManySeparators",
+			providerID: "us-central1-b/garm-instance/extra",
+			expectedOk: false,
+		},
+		{
+			name:       "MissingName",
+			providerID: "us-central1-b/",
+			expectedOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			zone, name, ok := splitRegionalProviderID(tt.providerID)
+			require.Equal(t, tt.expectedOk, ok)
+			require.Equal(t, tt.expectedZone, zone)
+			require.Equal(t, tt.expectedName, name)
+		})
+	}
+}

--- a/internal/spec/regional_placement.go
+++ b/internal/spec/regional_placement.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Cloudbase Solutions SRL
+//
+//    Licensed under the Apache License, Version 2.0 (the "License"); you may
+//    not use this file except in compliance with the License. You may obtain
+//    a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//    License for the specific language governing permissions and limitations
+//    under the License.
+
+package spec
+
+import (
+	"fmt"
+	"strings"
+)
+
+type RegionalPlacement struct {
+	Zones []string `json:"zones" jsonschema:"description=Compute Engine zones allowed for regional placement. All zones must belong to one region."`
+}
+
+func (p *RegionalPlacement) Validate() error {
+	if p == nil {
+		return nil
+	}
+	if len(p.Zones) == 0 {
+		return fmt.Errorf("regional_placement.zones must not be empty")
+	}
+
+	region := ""
+	seen := make(map[string]struct{}, len(p.Zones))
+	for _, zone := range p.Zones {
+		zoneRegion, err := regionFromZone(zone)
+		if err != nil {
+			return fmt.Errorf("invalid regional placement zone '%s': %w", zone, err)
+		}
+		if region == "" {
+			region = zoneRegion
+		} else if region != zoneRegion {
+			return fmt.Errorf("regional placement zones must belong to one region")
+		}
+		if _, ok := seen[zone]; ok {
+			return fmt.Errorf("duplicate regional placement zone '%s'", zone)
+		}
+		seen[zone] = struct{}{}
+	}
+	return nil
+}
+
+func (p *RegionalPlacement) Region() string {
+	if p == nil || len(p.Zones) == 0 {
+		return ""
+	}
+	region, _ := regionFromZone(p.Zones[0])
+	return region
+}
+
+func regionFromZone(zone string) (string, error) {
+	lastDash := strings.LastIndex(zone, "-")
+	suffix := zone[lastDash+1:]
+	if lastDash <= 0 || len(suffix) != 1 || suffix[0] < 'a' || suffix[0] > 'z' {
+		return "", fmt.Errorf("expected a zone name with a hyphen-delimited suffix")
+	}
+	return zone[:lastDash], nil
+}

--- a/internal/spec/regional_placement_test.go
+++ b/internal/spec/regional_placement_test.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2024 Cloudbase Solutions SRL
+//
+//	Licensed under the Apache License, Version 2.0 (the "License"); you may
+//	not use this file except in compliance with the License. You may obtain
+//	a copy of the License at
+//
+//	     http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//	WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//	License for the specific language governing permissions and limitations
+//	under the License.
+
+package spec
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cloudbase/garm-provider-common/params"
+	"github.com/cloudbase/garm-provider-gcp/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegionalPlacementValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		placement *RegionalPlacement
+		errString string
+	}{
+		{
+			name:      "ValidZones",
+			placement: &RegionalPlacement{Zones: []string{"us-central1-a", "us-central1-b"}},
+			errString: "",
+		},
+		{
+			name:      "MissingZones",
+			placement: &RegionalPlacement{},
+			errString: "regional_placement.zones must not be empty",
+		},
+		{
+			name:      "DuplicateZone",
+			placement: &RegionalPlacement{Zones: []string{"us-central1-a", "us-central1-a"}},
+			errString: "duplicate regional placement zone 'us-central1-a'",
+		},
+		{
+			name:      "ZonesAcrossRegions",
+			placement: &RegionalPlacement{Zones: []string{"us-central1-a", "us-east1-b"}},
+			errString: "regional placement zones must belong to one region",
+		},
+		{
+			name:      "MalformedZone",
+			placement: &RegionalPlacement{Zones: []string{"us-central1"}},
+			errString: "expected a zone name with a hyphen-delimited suffix",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.placement.Validate()
+			if tt.errString == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.errString)
+			}
+		})
+	}
+}
+
+func TestRegionalPlacementRegion(t *testing.T) {
+	var placement *RegionalPlacement
+	require.Equal(t, "", placement.Region())
+
+	placement = &RegionalPlacement{Zones: []string{"us-central1-a", "us-central1-b"}}
+	require.Equal(t, "us-central1", placement.Region())
+}
+
+func TestRegionalPlacementRequiresProviderOptIn(t *testing.T) {
+	DefaultToolFetch = func(osType params.OSType, osArch params.OSArch, tools []params.RunnerApplicationDownload) (params.RunnerApplicationDownload, error) {
+		return params.RunnerApplicationDownload{}, nil
+	}
+	cfg := &config.Config{
+		Zone:         "europe-west1-d",
+		ProjectId:    "my-project",
+		NetworkID:    "my-network",
+		SubnetworkID: "my-subnetwork",
+	}
+	data := params.BootstrapInstance{
+		Name:       "garm-instance",
+		ExtraSpecs: json.RawMessage(`{"regional_placement": {"zones": ["us-central1-a", "us-central1-b"]}}`),
+	}
+
+	_, err := GetRunnerSpecFromBootstrapParams(cfg, data, "my-controller")
+	require.ErrorContains(t, err, "requires enable_regional_placement")
+
+	cfg.EnableRegionalPlacement = true
+	spec, err := GetRunnerSpecFromBootstrapParams(cfg, data, "my-controller")
+	require.NoError(t, err)
+	require.Equal(t, "us-central1", spec.RegionalPlacement.Region())
+}

--- a/internal/spec/spec.go
+++ b/internal/spec/spec.go
@@ -124,6 +124,20 @@ func (e *extraSpecs) Validate() error {
 			return fmt.Errorf("network tag '%s' does not match requirements", tag)
 		}
 	}
+	if e.RegionalPlacement != nil {
+		if e.DisplayDevice {
+			return fmt.Errorf("regional_placement cannot be combined with display_device")
+		}
+		if e.SourceSnapshot != "" {
+			return fmt.Errorf("regional_placement cannot be combined with source_snapshot")
+		}
+		if len(e.CustomLabels) > 60 {
+			return fmt.Errorf("regional placement custom labels cannot exceed 60 items")
+		}
+		if err := e.RegionalPlacement.Validate(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -147,6 +161,8 @@ type extraSpecs struct {
 	EnableIntegrityMonitoring bool `json:"enable_integrity_monitoring,omitempty" jsonschema:"description=Enable integrity monitoring on the VM."`
 	// CMEK (Customer-Managed Encryption Key) for boot disk
 	BootDiskKmsKeyName string `json:"boot_disk_kms_key_name,omitempty" jsonschema:"description=The Cloud KMS key to use for boot disk encryption. Format: projects/{project}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{key}"`
+	// Regional placement options
+	RegionalPlacement *RegionalPlacement `json:"regional_placement,omitempty" jsonschema:"description=Optional regional placement using the pool's existing flavor and image."`
 	// The Cloudconfig struct from common package
 	cloudconfig.CloudConfigSpec
 }
@@ -181,6 +197,9 @@ func GetRunnerSpecFromBootstrapParams(cfg *config.Config, data params.BootstrapI
 	}
 
 	spec.MergeExtraSpecs(extraSpecs)
+	if spec.RegionalPlacement != nil && !cfg.EnableRegionalPlacement {
+		return nil, fmt.Errorf("regional_placement requires enable_regional_placement in the provider config")
+	}
 
 	return spec, nil
 }
@@ -209,6 +228,8 @@ type RunnerSpec struct {
 	EnableIntegrityMonitoring bool
 	// CMEK (Customer-Managed Encryption Key) for boot disk
 	BootDiskKmsKeyName string
+	// Regional placement options
+	RegionalPlacement *RegionalPlacement
 }
 
 func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
@@ -264,6 +285,9 @@ func (r *RunnerSpec) MergeExtraSpecs(extraSpecs *extraSpecs) {
 	}
 	if extraSpecs.BootDiskKmsKeyName != "" {
 		r.BootDiskKmsKeyName = extraSpecs.BootDiskKmsKeyName
+	}
+	if extraSpecs.RegionalPlacement != nil {
+		r.RegionalPlacement = extraSpecs.RegionalPlacement
 	}
 }
 

--- a/internal/spec/spec_test.go
+++ b/internal/spec/spec_test.go
@@ -181,6 +181,15 @@ func TestJsonSchemaValidation(t *testing.T) {
 			errString: "",
 		},
 		{
+			name: "Specs just with regional_placement",
+			input: json.RawMessage(`{
+				"regional_placement": {
+					"zones": ["us-central1-a", "us-central1-b"]
+				}
+			}`),
+			errString: "",
+		},
+		{
 			name: "Invalid input for display_device - wrong data type",
 			input: json.RawMessage(`{
 				"display_device": "true"
@@ -270,6 +279,13 @@ func TestJsonSchemaValidation(t *testing.T) {
 				"extra_context": "key"
 			}`),
 			errString: "schema validation failed: [extra_context: Invalid type. Expected: object, given: string]",
+		},
+		{
+			name: "Invalid input for regional_placement - wrong data type",
+			input: json.RawMessage(`{
+				"regional_placement": "us-central1-a"
+			}`),
+			errString: "schema validation failed: [regional_placement: Invalid type. Expected: object, given: string]",
 		},
 		{
 			name: "Invalid input - additional property",
@@ -587,6 +603,39 @@ func TestExtraSpecsValidate(t *testing.T) {
 			},
 			wantErr: true,
 			errMsg:  "network tag '!invalidTag' does not match requirements",
+		},
+		{
+			name: "Valid regional placement",
+			specs: &extraSpecs{
+				RegionalPlacement: &RegionalPlacement{Zones: []string{"us-central1-a", "us-central1-b"}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Regional placement combined with display_device",
+			specs: &extraSpecs{
+				RegionalPlacement: &RegionalPlacement{Zones: []string{"us-central1-a"}},
+				DisplayDevice:     true,
+			},
+			wantErr: true,
+			errMsg:  "regional_placement cannot be combined with display_device",
+		},
+		{
+			name: "Regional placement combined with source_snapshot",
+			specs: &extraSpecs{
+				RegionalPlacement: &RegionalPlacement{Zones: []string{"us-central1-a"}},
+				SourceSnapshot:    "projects/garm-testing/global/snapshots/garm-snapshot",
+			},
+			wantErr: true,
+			errMsg:  "regional_placement cannot be combined with source_snapshot",
+		},
+		{
+			name: "Regional placement with invalid zones",
+			specs: &extraSpecs{
+				RegionalPlacement: &RegionalPlacement{Zones: []string{"us-central1-a", "us-east1-b"}},
+			},
+			wantErr: true,
+			errMsg:  "regional placement zones must belong to one region",
 		},
 	}
 

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -23,6 +23,8 @@ import (
 	"github.com/cloudbase/garm-provider-common/params"
 )
 
+const RegionalPlacementLabel string = "garmregionalplacement"
+
 func GetMachineType(zone, flavor string) string {
 	machine := fmt.Sprintf("zones/%s/machineTypes/%s", zone, flavor)
 	return machine
@@ -31,6 +33,25 @@ func GetMachineType(zone, flavor string) string {
 func GetInstanceName(name string) string {
 	lowerName := strings.ToLower(name)
 	return lowerName
+}
+
+func getZoneName(zone string) string {
+	parts := strings.Split(strings.TrimSuffix(zone, "/"), "/")
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[len(parts)-1]
+}
+
+func GetRegionalProviderID(instance *computepb.Instance) (string, error) {
+	if instance == nil || instance.Labels[RegionalPlacementLabel] != "true" {
+		return "", fmt.Errorf("instance is not marked for regional placement")
+	}
+	zone := getZoneName(instance.GetZone())
+	if zone == "" {
+		return "", fmt.Errorf("regional instance zone is missing")
+	}
+	return zone + "/" + GetInstanceName(instance.GetName()), nil
 }
 
 func getNameForInstance(instance *computepb.Instance) (string, error) {
@@ -66,11 +87,35 @@ func GcpInstanceToParamsInstance(gcpInstance *computepb.Instance) (params.Provid
 		return params.ProviderInstance{}, fmt.Errorf("instance name is nil")
 	}
 
-	details := params.ProviderInstance{
-		ProviderID: GetInstanceName(*gcpInstance.Name),
-		Name:       name,
-		OSType:     params.OSType(gcpInstance.Labels["ostype"]),
-		OSArch:     params.OSArch(*gcpInstance.Disks[0].Architecture),
+	var details params.ProviderInstance
+	if gcpInstance.Labels[RegionalPlacementLabel] == "true" {
+		providerID, err := GetRegionalProviderID(gcpInstance)
+		if err != nil {
+			return params.ProviderInstance{}, err
+		}
+		if len(gcpInstance.GetDisks()) == 0 || gcpInstance.GetDisks()[0].Architecture == nil {
+			return params.ProviderInstance{}, fmt.Errorf("regional instance boot disk architecture is missing")
+		}
+		details = params.ProviderInstance{
+			ProviderID: providerID,
+			Name:       name,
+			OSType:     params.OSType(gcpInstance.Labels["ostype"]),
+		}
+		switch strings.ToUpper(gcpInstance.Disks[0].GetArchitecture()) {
+		case "AMD64", "X86_64":
+			details.OSArch = params.Amd64
+		case "ARM64":
+			details.OSArch = params.Arm64
+		default:
+			return params.ProviderInstance{}, fmt.Errorf("unsupported regional instance architecture %s", gcpInstance.Disks[0].GetArchitecture())
+		}
+	} else {
+		details = params.ProviderInstance{
+			ProviderID: GetInstanceName(*gcpInstance.Name),
+			Name:       name,
+			OSType:     params.OSType(gcpInstance.Labels["ostype"]),
+			OSArch:     params.OSArch(*gcpInstance.Disks[0].Architecture),
+		}
 	}
 
 	switch gcpInstance.GetStatus() {

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -71,6 +71,23 @@ func TestGcpInstanceToParamsInstance(t *testing.T) {
 			errString: "",
 		},
 		{
+			name: "RegionalInstance",
+			gcpInstance: &computepb.Instance{
+				Name:   proto.String("garm-instance"),
+				Zone:   proto.String("zones/us-central1-b"),
+				Labels: map[string]string{"ostype": "linux", RegionalPlacementLabel: "true"},
+				Disks:  []*computepb.AttachedDisk{{Architecture: proto.String("X86_64")}},
+				Status: proto.String("RUNNING"),
+			},
+			expected: params.ProviderInstance{
+				ProviderID: "us-central1-b/garm-instance",
+				Name:       "garm-instance",
+				OSType:     "linux",
+				OSArch:     params.Amd64,
+				Status:     "running",
+			},
+		},
+		{
 			name:        "NilGcpInstance",
 			gcpInstance: nil,
 			expected:    params.ProviderInstance{},

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -69,6 +69,13 @@ func (g *GcpProvider) CreateInstance(ctx context.Context, bootstrapParams params
 		OSArch:     spec.BootstrapParams.OSArch,
 		Status:     "running",
 	}
+	if spec.RegionalPlacement != nil {
+		providerID, err := util.GetRegionalProviderID(inst)
+		if err != nil {
+			return params.ProviderInstance{}, fmt.Errorf("failed to get regional provider ID: %w", err)
+		}
+		instance.ProviderID = providerID
+	}
 	return instance, nil
 }
 


### PR DESCRIPTION
This adds an opt-in regional placement mode to the provider. Pools can set a
new `regional_placement` extra spec listing the zones (all in one region) a
runner may land in. When set, the provider creates the instance through a
regional bulk insert with an `ANY_SINGLE_ZONE` location policy, so Compute
Engine picks a zone with available capacity instead of failing when a single
configured zone runs dry.

Because the zone is no longer fixed, these runners get a `zone/instance-name`
provider ID, and delete/status operations resolve the zone from the ID (or
search the allowed zones). Instances carry a `garmregionalplacement` label so
pool listings include them across zones via an aggregated list.

The feature is fully opt-in and changes nothing by default:

- the operator must set `enable_regional_placement = true` in the provider
  config, and
- each pool must opt in via the `regional_placement` extra spec.

Notes:

- `regional_placement` cannot be combined with `display_device` or
  `source_snapshot`.
- bulk inserts are idempotent via a request ID, and create errors that may
  still have landed on the GCP side are reconciled by looking up the instance
  before reporting failure, so GARM does not leak running VMs.

Tested with `go test -race ./...`. The README documents the new config option
and extra spec schema.
